### PR TITLE
Update examples submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = https://github.com/JiscRDSS/rdss-par-examples.git
+	url = https://github.com/openpreserve/par-examples.git


### PR DESCRIPTION
It still points to https://github.com/JiscRDSS/rdss-par-examples.git instead of https://github.com/openpreserve/par-examples.