### PR TITLE
Fixed toolAcceptedParameters type

### DIFF
--- a/schema/tool.json
+++ b/schema/tool.json
@@ -15,7 +15,7 @@
         },
         "toolAcceptedParameters": {
           "items": {
-            "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parameter"
+            "$ref": "http://www.parcore.org/schema/types.json/#/definitions/inputToolArgument"
           },
           "type": "array",
           "uniqueItems": true


### PR DESCRIPTION
Changed reference to `types.json/#/definitions/inputToolArgument` as the current `types.json/#/definitions/parameter` does not exist