### PR TITLE
FEAT: PAR ID refs in FormatFamily arrays

### DIFF
--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -45,7 +45,7 @@ definitions:
         type: string
       formatFamilies:
         items:
-          $ref: '#/definitions/FormatFamily'
+          $ref: '#/definitions/ParIdentifier'
         type: array
       formats:
         items:
@@ -251,7 +251,7 @@ definitions:
         type: array
       formatFamilies:
         items:
-          $ref: '#/definitions/FormatFamily'
+          $ref: '#/definitions/ParIdentifier'
         type: array
       id:
         $ref: '#/definitions/ParIdentifier'

--- a/schema/business-rule.json
+++ b/schema/business-rule.json
@@ -51,7 +51,7 @@
     "formatFamilies": {
       "description": "A list of format families that this Business Rule should be applied to",
       "items": {
-        "$ref": "http://www.parcore.org/schema/types.json/#/definitions/formatFamily"
+        "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parIdentifier"
       },
       "type": "array"
     },

--- a/schema/types.json
+++ b/schema/types.json
@@ -15,6 +15,12 @@
           },
           "type": "array"
         },
+        "formatFamilies": {
+          "items": {
+            "$ref": "#/definitions/parIdentifier"
+          },
+          "type": "array"
+        },
         "identifier": {
           "$ref": "#/definitions/parIdentifier"
         }


### PR DESCRIPTION
- changed BusinessRule.formatFamilies and FormatFamily.formatFamilies in `api/par-api.yaml`;
- added missing formatFamilies property FormatFamily in `schema/types.json`; and
- changed BusinessRule.formatFamilies in `schema/business-rule.json`.