### PR TITLE
FEAT: API document publication

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 lsi: false
 safe: true
-source: /docs/
+source: ./
 incremental: false
 highlighter: rouge
 gist:

--- a/docs/_data/navbar.yml
+++ b/docs/_data/navbar.yml
@@ -1,6 +1,16 @@
 - title: "Overview"
   href: "/"
 
+- title: "API"
+  href: "/api/"
+  subcategories:
+    - subtitle: "1.0"
+      subhref: "1.0/"
+    - subtitle: "1.1"
+      subhref: "1.1/"
+    - subtitle: "1.2"
+      subhref: "1.2/"
+
 - title: "Roadmap"
   href: "/roadmap/"
 

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -7,14 +7,24 @@
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav mr-auto">
       {% for item in include.nav %}
-        {% if item.url == navurl %}
-        <li class="nav-item active">
+        {% if item.subcategories != null %}
+        <li class="dropdown">
+          <a href="{{ site.url }}{{ item.href }}" class="nav-link dropdown-toggle" data-toggle="dropdown" data-hover="dropdown">{{ item.title }} <span class="caret"></a>
+          <ul class="dropdown-menu">
+          {% for subcategory in item.subcategories %}
+            <li><a href="{{ site.url }}{{ item.href }}{{ subcategory.subhref }}">{{ subcategory.subtitle }}</a></li>
+          {% endfor %}
+          </ul>
         {% else %}
-        <li class="nav-item">
-        {% endif %}
+          {% if item.url == navurl %}
+            <li class="nav-item active">
+          {% else %}
+            <li class="nav-item">
+          {% endif %}
           <a class="nav-link" href="{{ site.url }}{{ item.href }}">{{ item.title }}</a>
+        {% endif %}
         </li>
-        {% endfor %}
+      {% endfor %}
       </ul>
     </div>
   </nav>

--- a/docs/_layouts/forward.html
+++ b/docs/_layouts/forward.html
@@ -1,0 +1,44 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {% assign time = 0 %}
+    {% assign targetname = page.target %}
+ 
+    {% if page.time %}
+    {% assign time = page.time %}
+    {% endif %}
+    
+    {% if page.targetname %}
+    {% assign targetname = page.targetname %}
+    {% endif %}
+
+    {% capture title %}Redirecting to {{ targetname }}{% endcapture %}
+    {% if page.targettitle %}
+    {% assign title = page.targettitle %}
+    {% endif %}
+    <meta http-equiv="refresh" content="{{ time }};url={{ page.target }}"/>
+    <link rel="canonical" href="{{ page.target }}"/>
+    <title>{{ title }}</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            max-width: 40em;
+            margin: 1em auto;
+        }
+    </style>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+   
+    {% if page.message %}
+    <p>{{ page.message }}</p>
+    {% else %}
+    <p>This document has moved!</p>
+    {% endif %}
+
+    <p>Redirecting to <a href="{{ page.target }}">{{ targetname }}</a> in {{ time }} seconds.</p>
+
+</body>
+</html>

--- a/docs/api/1.0/index.html
+++ b/docs/api/1.0/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>My New API</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "par-api.yaml", //Location of Open API spec in the repo
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/docs/api/1.0/par-api.yaml
+++ b/docs/api/1.0/par-api.yaml
@@ -1,0 +1,5138 @@
+basePath: /par
+definitions:
+  Action:
+    properties:
+      optionalInputFiles:
+        items:
+          $ref: '#/definitions/InputFile'
+        type: array
+      optionalInputProperties:
+        items:
+          $ref: '#/definitions/InputProperty'
+        type: array
+      outputFilesRetrieved:
+        items:
+          $ref: '#/definitions/OutputFile'
+        type: array
+      outputPropertiesRetrieved:
+        items:
+          $ref: '#/definitions/OutputProperty'
+        type: array
+      preservationAction:
+        $ref: '#/definitions/ParIdentifier'
+      priority:
+        format: int32
+        type: integer
+      rawOutputsRetrieved:
+        items:
+          $ref: '#/definitions/OutputRaw'
+        type: array
+  AuthorInformation:
+    properties:
+      authorCompoundName:
+        type: string
+      authorId:
+        type: string
+      authorIdNamespace:
+        type: string
+      authorName:
+        type: string
+      organisationName:
+        type: string
+  BusinessRule:
+    properties:
+      description:
+        type: string
+      formatFamilies:
+        items:
+          $ref: '#/definitions/FormatFamily'
+        type: array
+      formats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      notes:
+        type: string
+      preservationActionTypes:
+        items:
+          $ref: '#/definitions/PreservationActionType'
+        type: array
+      preservationActions:
+        items:
+          $ref: '#/definitions/Action'
+        type: array
+  BusinessRules:
+    properties:
+      businessRules:
+        items:
+          $ref: '#/definitions/BusinessRule'
+        type: array
+  ByteSequenceInformation:
+    properties:
+      byteSequenceId:
+        type: string
+      byteSequenceIdNamespace:
+        type: string
+      byteSequenceValue:
+        type: string
+      endianness:
+        type: string
+      indirectOffsetLength:
+        type: string
+      indirectOffsetLocation:
+        type: string
+      maxOffset:
+        type: string
+      offset:
+        type: string
+      positionType:
+        type: string
+  DeveloperInformation:
+    properties:
+      developerCompoundName:
+        type: string
+      developerId:
+        type: string
+      developerIdNamespace:
+        type: string
+      developerName:
+        type: string
+      organisationName:
+        type: string
+  DocumentInformation:
+    properties:
+      author:
+        $ref: '#/definitions/AuthorInformation'
+      availabilityDescription:
+        type: string
+      availabilityNote:
+        type: string
+      displayText:
+        type: string
+      documentIPR:
+        type: string
+      documentId:
+        type: string
+      documentIdNamespace:
+        type: string
+      documentNote:
+        type: string
+      documentType:
+        type: string
+      publicationDate:
+        type: string
+      publisher:
+        $ref: '#/definitions/PublisherInformation'
+      titleText:
+        type: string
+  ExternalSignatureInformation:
+    properties:
+      externalSignatureId:
+        type: string
+      externalSignatureIdNamespace:
+        type: string
+      signature:
+        type: string
+      signatureType:
+        type: string
+  FileCriterion:
+    properties:
+      formats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      formatFamilies:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      minimum:
+        type: string
+        description: (representing a number)
+      maximum:
+        type: string
+        description: (representing a number or "unbounded")
+  FileFormat:
+    properties:
+      aliases:
+        items:
+          type: string
+        type: array
+      binaryFileFormat:
+        type: string
+      byteOrders:
+        items:
+          type: string
+        type: array
+      description:
+        type: string
+      developers:
+        items:
+          $ref: '#/definitions/DeveloperInformation'
+        type: array
+      disclosure:
+        type: string
+      documents:
+        items:
+          $ref: '#/definitions/DocumentInformation'
+        type: array
+      externalSignatures:
+        items:
+          $ref: '#/definitions/ExternalSignatureInformation'
+        type: array
+      families:
+        items:
+          type: string
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      identifiers:
+        items:
+          $ref: '#/definitions/IdentifierInformation'
+        type: array
+      internalSignatures:
+        items:
+          $ref: '#/definitions/InternalSignatureInformation'
+        type: array
+      lastUpdatedDate:
+        type: string
+      localLastModifiedDate:
+        type: string
+      name:
+        type: string
+      note:
+        type: string
+      provenance:
+        $ref: '#/definitions/ProvenanceInformation'
+      registryVersions:
+        items:
+          $ref: '#/definitions/RegistryVersionInformation'
+        type: array
+      relatedFormats:
+        items:
+          $ref: '#/definitions/RelatedFormatInformation'
+        type: array
+      releaseDate:
+        type: string
+      risk:
+        type: string
+      technicalEnvironment:
+        type: string
+      types:
+        items:
+          type: string
+        type: array
+      version:
+        type: string
+      withdrawnDate:
+        type: string
+  FileFormats:
+    properties:
+      fileFormats:
+        items:
+          $ref: '#/definitions/FileFormat'
+        type: array
+  FormatFamilies:
+    properties:
+      formatFamilies:
+        items:
+          $ref: '#/definitions/FormatFamily'
+        type: array
+  FormatFamily:
+    properties:
+      familyType:
+        type: string
+      fileFormats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+  IdentifierInformation:
+    properties:
+      identifier:
+        type: string
+      identifierType:
+        type: string
+  InputFile:
+    properties:
+      description:
+        type: string
+      file:
+        $ref: '#/definitions/ParFile'
+      name:
+        type: string
+  InputProperty:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      parProperty:
+        $ref: '#/definitions/ParProperty'
+  InputToolArgument:
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+      value:
+        type: string
+  InternalSignatureInformation:
+    properties:
+      byteSequences:
+        items:
+          $ref: '#/definitions/ByteSequenceInformation'
+        type: array
+      signatureId:
+        type: string
+      signatureIdNamespace:
+        type: string
+      signatureName:
+        type: string
+      signatureNote:
+        type: string
+  OutputFile:
+    properties:
+      description:
+        type: string
+      file:
+        $ref: '#/definitions/ParFile'
+      name:
+        type: string
+  OutputProperty:
+    properties:
+      description:
+        type: string
+      groupIdBinding:
+        type: string
+      groupLabel:
+        type: string
+      name:
+        type: string
+      parProperty:
+        $ref: '#/definitions/ParProperty'
+      toolBinding:
+        type: string
+  OutputRaw:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      value:
+        type: string
+  ParFile:
+    properties:
+      filepath:
+        type: string
+  ParIdentifier:
+    properties:
+      guid:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+  ParProperties:
+    properties:
+      parProperties:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+  ParProperty:
+    properties:
+      class:
+        type: string
+      description:
+        type: string
+      equivalentTo:
+        items:
+          type: string
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      type:
+        type: string
+      units:
+        type: string
+      value:
+        type: string
+  PreservationAction:
+    properties:
+      constraints:
+        items:
+          $ref: '#/definitions/PreservationActionConstraints'
+        type: array
+      description:
+        type: string
+      example:
+        type: string
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      inputFiles:
+        items:
+          $ref: '#/definitions/InputFile'
+        type: array
+      inputProperties:
+        items:
+          $ref: '#/definitions/InputProperty'
+        type: array
+      inputToolArguments:
+        items:
+          $ref: '#/definitions/InputToolArgument'
+        type: array
+      localLastModifiedDate:
+        type: string
+      outputFiles:
+        items:
+          $ref: '#/definitions/OutputFile'
+        type: array
+      outputProperties:
+        items:
+          $ref: '#/definitions/OutputProperty'
+        type: array
+      rawOutputs:
+        items:
+          $ref: '#/definitions/OutputRaw'
+        type: array
+      tool:
+        $ref: '#/definitions/Tool'
+      type:
+        $ref: '#/definitions/PreservationActionType'
+  PreservationActionConstraints:
+    properties:
+      allowedFormats:
+        items:
+          $ref: '#/definitions/FileFormat'
+        type: array
+      allowedPropertiesAllOf:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+      allowedPropertiesAnyOf:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+      inputItemName:
+        type: string
+  PreservationActionType:
+    properties:
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      label:
+        type: string
+      localLastModifiedDate:
+        type: string
+  PreservationActionTypes:
+    properties:
+      preservationActionTypes:
+        items:
+          $ref: '#/definitions/PreservationActionType'
+        type: array
+  PreservationActions:
+    properties:
+      preservationActions:
+        items:
+          $ref: '#/definitions/PreservationAction'
+        type: array
+  ProvenanceInformation:
+    properties:
+      provenanceDescription:
+        type: string
+      provenanceName:
+        type: string
+      provenanceSourceDate:
+        type: string
+      provenanceSourceId:
+        type: string
+      provenanceSourceNamespace:
+        type: string
+  PublisherInformation:
+    properties:
+      organisationName:
+        type: string
+      publisherCompoundName:
+        type: string
+      publisherId:
+        type: string
+      publisherIdNamespace:
+        type: string
+      publisherName:
+        type: string
+  RegistryVersionInformation:
+    properties:
+      name:
+        type: string
+      registryNamespace:
+        type: string
+      version:
+        type: string
+  RelatedFormatInformation:
+    properties:
+      relatedFormatId:
+        type: string
+      relatedFormatIdNamespace:
+        type: string
+      relatedFormatName:
+        type: string
+      relatedFormatVersion:
+        type: string
+      relationshipType:
+        type: string
+  RepresentationFormat:
+    properties:
+      description:
+        type: string
+      hasPriorityOver:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      name:
+        type: string
+      representationFormatSignature:
+        $ref: '#/definitions/RepresentationFormatSignature'
+  RepresentationFormats:
+    properties:
+      representationFormats:
+        items:
+          $ref: '#/definitions/RepresentationFormat'
+        type: array
+  RepresentationFormatSignature:
+    properties:
+      fileCriteria:
+        items:
+          $ref: '#/definitions/FileCriterion'
+        type:
+          array
+      primaryFileCriteria:
+        items:
+          $ref: '#/definitions/FileCriterion'
+        type:
+          array
+  Tool:
+    properties:
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      toolAcceptedParameters:
+        items:
+          type: string
+        type: array
+      toolLabel:
+        type: string
+      toolName:
+        type: string
+      toolOperatingEnvironments:
+        items:
+          type: string
+        type: array
+      toolPublisher:
+        type: string
+      toolVersion:
+        type: string
+  Tools:
+    properties:
+      tools:
+        items:
+          $ref: '#/definitions/Tool'
+        type: array
+host: parcore.org
+info:
+  description: >-
+    API to retrieve and update Business Rules, Preservation Actions etc from a
+    Preservation Action Registries compliant endpoint
+  title: PAR API
+  version: '1.0'
+paths:
+  /business-rules:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Business Rules that match all of the filter
+        conditions supplied. Any number of fitlers can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Business Rules modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Business Rules whose purpose is to perform
+            one of the listed types of action.
+          in: header
+          name: preservation-action-type
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of NAMEs of file formats (i.e. fmt/1,
+            x-fmt/2. This filter matches only those Business Rules that have
+            been defined to apply to one of the listed formats. This includes
+            formats where the rule is applicable indirectly through the format
+            family.
+          in: header
+          name: file-format
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Business Rules. This filter
+            matches only those Business Rules that are identified by one of the
+            listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Business Rules whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Business Rules whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Business Rule to return from the start of the list of all
+            matching Business Rules.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Business Rules to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "businessRules" : [ {
+                  "id" : {
+                    "guid" : "cb2bea88-8006-58fa-a395-dcf0d76a32ee",
+                    "name" : "mediainfo-extraction-of-video",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "For property extraction of Video file formats, use the MediaInfo CLI",
+                  "formats" : [ {
+                    "guid" : "6590d828-10ac-5aa4-aaf8-36f073343432",
+                    "name" : "fmt/735",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "e534e808-9680-5945-8046-5fface23cd93",
+                    "name" : "fmt/951",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "84dbb5f7-b722-5817-8762-e05c1ef17759",
+                    "name" : "fmt/973",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "993a1df3-7da3-5972-b765-431195b3f009",
+                    "name" : "fmt/1086",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "61a35b4f-34c0-51b4-9dd3-8f03c79b69a8",
+                    "name" : "x-fmt/139",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9fdb2a8d-3143-54c1-a3ae-83f122b5fd4c",
+                    "name" : "x-fmt/419",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "formatFamilies" : [ {
+                    "id" : {
+                      "guid" : "60303765-0d86-5f48-a26c-96daec3b754b",
+                      "name" : "video",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Video File Formats",
+                    "fileFormats" : [ {
+                      "guid" : "dfc92377-0582-584b-9bce-661cc365b10d",
+                      "name" : "TSS-fmt/4",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                      "name" : "fmt/649",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                      "name" : "fmt/506",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f3252fc5-f9fe-5b4f-925e-edc4653a7ff0",
+                      "name" : "fmt/193",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                      "name" : "fmt/786",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                      "name" : "fmt/131",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                      "name" : "fmt/499",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                      "name" : "fmt/133",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                      "name" : "fmt/199",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                      "name" : "fmt/200",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "9947c06d-591e-56bd-98df-8c15a5d38655",
+                      "name" : "TSS-fmt/13",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "cc6f693f-3e92-5e6c-a5f4-dde355f9b498",
+                      "name" : "TSS-fmt/15",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "36ce7b02-d2cb-5d23-bad3-de475d3e8eea",
+                      "name" : "fmt/105",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                      "name" : "x-fmt/385",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "82c41aa8-bf6a-50ba-97b1-d28f3b25d77a",
+                      "name" : "fmt/107",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "eba99ac5-b80b-560f-9d0f-cb371260246d",
+                      "name" : "TSS-fmt/11",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                      "name" : "fmt/109",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "ec00c475-d655-57f0-b2df-aefe8c0c943e",
+                      "name" : "TSS-fmt/9",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                      "name" : "fmt/507",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                      "name" : "fmt/505",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                      "name" : "fmt/945",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                      "name" : "fmt/569",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "80a02837-3b02-5e43-beb8-b8121343da71",
+                      "name" : "fmt/1055",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                      "name" : "fmt/731",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "83e012dd-d83c-577f-982f-07d2e846e93d",
+                      "name" : "fmt/110",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "98bdd321-0f14-5ff8-b174-5470977c4fb4",
+                      "name" : "TSS-fmt/3",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                      "name" : "fmt/5",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                      "name" : "fmt/585",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "e104d7fb-0d2c-55d7-ba89-65cdd41b5be7",
+                      "name" : "fmt/640",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                      "name" : "fmt/573",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "b4471a17-e68e-5979-9299-7e9f78772d89",
+                      "name" : "TSS-fmt/14",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                      "name" : "x-fmt/386",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "2253f81a-8692-5ddd-8010-99c2a2461360",
+                      "name" : "fmt/104",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "2d398b99-4a15-5fb9-93ad-c6dfa86b8d78",
+                      "name" : "TSS-fmt/16",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                      "name" : "fmt/425",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f92ffa76-ef89-55df-89ef-94bca58e4e2d",
+                      "name" : "TSS-fmt/10",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "3aa32617-a451-5fe2-856f-b5e0e0b5b968",
+                      "name" : "fmt/106",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                      "name" : "fmt/108",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dd86844e-3988-55ac-bc19-43bfe86be1ba",
+                      "name" : "TSS-fmt/12",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                      "name" : "x-fmt/152",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                      "name" : "x-fmt/384",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                      "name" : "x-fmt/190",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                      "name" : "x-fmt/382",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "ae7ebffb-5140-53a6-9a9a-adbe90953f45",
+                      "name" : "asf",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                      "name" : "fmt/131",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                      "name" : "fmt/505",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                      "name" : "fmt/506",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                      "name" : "fmt/507",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dbd65709-a393-5d73-9b68-0355972532ba",
+                      "name" : "x-fmt/137",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "7c62e0ea-4846-52d4-b62b-ab99d7084d7d",
+                      "name" : "wma",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "eb916390-88b6-5431-b8e3-cf03e44c7554",
+                      "name" : "fmt/132",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "c6c99061-2702-5b83-98fe-e6f46d1c007b",
+                      "name" : "mpeg-audio",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "6efff7b7-3ddb-57ab-85bb-3501ba202afe",
+                      "name" : "fmt/134",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "76a512ae-6c0b-5e11-bf2f-714ffa770ea2",
+                      "name" : "fmt/198",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "984e8161-82c7-5821-9b08-2ed9580b0fd5",
+                      "name" : "fmt/347",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a7d7cb5-f8f7-5414-b155-f6558cf9e897",
+                      "name" : "x-fmt/279",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "ae87efa4-cd5a-5d07-b1b7-251a4fe871c8",
+                      "name" : "ogg",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "9ba33cd0-6339-5add-9c10-cd9a430a1d84",
+                      "name" : "fmt/203",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                      "name" : "fmt/945",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "98adc483-d0cd-58b4-84d8-0d4117b53089",
+                      "name" : "fmt/946",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "d67128ec-b34b-525a-a228-0c5cf692b22c",
+                      "name" : "fmt/947",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "d04d2361-05d5-582f-a83c-c573f6e34cc1",
+                      "name" : "fmt/948",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                      "name" : "video-extract-mediainfo",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use MediaInfo for Property Extraction"
+                }, {
+                  "id" : {
+                    "guid" : "9396cbc6-03d2-5195-ac8e-05017913defc",
+                    "name" : "property-extraction-of-camera-raw",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "For Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW Images use ExifTool",
+                  "formats" : [ {
+                    "guid" : "026d9445-7056-5824-adf8-0ab7db541319",
+                    "name" : "fmt/202",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "1fff9428-6bf2-5a90-8afd-c560a63d2f33",
+                    "name" : "fmt/642",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "29814d1c-020e-5156-9405-3562137b4295",
+                    "name" : "fmt/668",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4b8cac87-b6ba-57d4-8f4e-02f35ba32c64",
+                    "name" : "fmt/669",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                      "name" : "extract-camera-raw",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use ExifTool for Nikon, Fujifilm, Olympus and Minolta RAW Image Property Extraction"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/BusinessRules'
+      summary: Get Business Rules
+      tags:
+        - /business-rules
+    post:
+      consumes: []
+      description: Creates a new Business Rule and returns the rule as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/BusinessRule'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Business Rule
+      tags:
+        - /business-rules
+  /business-rules/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Business Rule successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Business Rule
+      tags:
+        - /business-rules
+    get:
+      consumes: []
+      description: Returns the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '404':
+          description: >-
+            If the specified guid does not reference a Business Rule known to
+            this registry.
+      summary: Get a Business Rule
+      tags:
+        - /business-rules
+    put:
+      consumes: []
+      description: >-
+        Updates the Business Rule specified by the GUID of the PAR Identifier
+        and returns the rule as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/BusinessRule'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Business Rule
+      tags:
+        - /business-rules
+  /file-formats:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of File Formats that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any FileFormats modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of the Name part of the ParIdentifier of FileFormats. This filter matches
+            only those File Formats that are identified by one of the listed Names. (n.b. this header is named
+            GUID but uses names in v1.0)
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those File Formats whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those File Formats whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first FileFormat to return from the start of the list of all
+            matching File Formats.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of FileFormats to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "fileFormats" : [ {
+                  "description" : "This is an outline record only, and requires further details, research or authentication to provide information that will enable users to further understand the format and to assess digital preservation risks associated with it if appropriate.",
+                  "externalSignatures" : [ {
+                    "signature" : "f4a",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "m4v",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "m4a",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "f4v",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mp4",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                    "name" : "fmt/199",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/357",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "66747970{0-64}(6D703432|6D703431|69736F6D|69736F32)*6D6F6F76",
+                      "maxOffset" : "0",
+                      "offset" : "4",
+                      "positionType" : "Absolute from BOF"
+                    } ],
+                    "signatureId" : "is/278",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2017-07-05T20:22:48Z",
+                  "name" : "MPEG-4 Media File",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "x-fmt/384",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Quicktime",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/596",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Apple Lossless Audio Codec",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/357",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "3GPP Audio/Video File",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Video" ],
+                  "version" : "\n      "
+                }, {
+                  "description" : "MPEG-2 is a lossy compression standard (an improvement and expansion of the MPEG-1 standard) designed for the generic coding of video and audio and intended to cover a wide scope of application, including: video production, broadcast and editing. Streams are at potentially higher bitrates than MPEG-1 but more efficient compression making it suited to High Definition video. MPEG-2 Video supports both 'progressive' and 'interlaced' frame video. An MPG-2 ‘Program’ stream (PS) file (*.mpg, *.mpeg) generally contain both video and audio streams, generally for synchronised playback, and may carry a variety of other data (e.g. video captions).\n\nSome camcorders store their MPEG-2 Program Stream video data as files with the .mod extension, usually alongside other files containing metadata and management information for the video.",
+                  "externalSignatures" : [ {
+                    "signature" : "mod",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mpeg",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mpg",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                    "name" : "x-fmt/386",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "identifiers" : [ {
+                    "identifier" : "x-fmt/386",
+                    "identifierType" : "PUID"
+                  }, {
+                    "identifier" : "video/mpeg",
+                    "identifierType" : "MIME"
+                  } ],
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/800",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "000001BA{8-12}000001BB{8-65536}000001B3{8-136}000001B5",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Absolute from BOF"
+                    } ],
+                    "signatureId" : "is/655",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2019-07-30T19:28:46Z",
+                  "name" : "MPEG-2 Program Stream",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "x-fmt/385",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "MPEG-1 Program Stream",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/425",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Video Object File (MPEG-2 subset)",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Video" ],
+                  "version" : "\n      "
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FileFormats'
+      summary: Get File Formats
+      tags:
+        - /file-formats
+    post:
+      consumes: []
+      description: Creates a new FileFormat and returns the fileFormat as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FileFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create FileFormat
+      tags:
+        - /file-formats
+  /file-formats/{name}:
+    delete:
+      consumes: []
+      description: Deletes the File Format specified by the Name part of the PAR Identifier
+      parameters:
+        - in: path
+          name: name
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: File Format successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete File Format
+      tags:
+        - /file-formats
+    get:
+      consumes: []
+      description: Returns the File Format specified by the Name part of the PAR Identifier
+      parameters:
+        - in: path
+          name: name
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '404':
+          description: >-
+            If the specified name does not reference a File Format known to this
+            registry.
+      summary: Get a File Format
+      tags:
+        - /file-formats
+    put:
+      consumes: []
+      description: >-
+        Updates the File Format specified by the Name part of the PAR Identifier and
+        returns the file format as updated.
+      parameters:
+        - in: path
+          name: name
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FileFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update File Format
+      tags:
+        - /file-formats
+  /format-families:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Format Families that match all of the filter
+        conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Format Families modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of NAMEs of file formats (i.e. fmt/1,
+            x-fmt/2. This filter matches only those Format Families that include
+            any of the specified formats.
+          in: header
+          name: file-format
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Format Families. This filter
+            matches only those Format Families that are identified by one of the
+            listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Format Families whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Format Families whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Format Family to return from the start of the list of all
+            matching Format Families.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Format Families to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "formatFamilies" : [ {
+                  "id" : {
+                    "guid" : "d7df91be-c3d1-51f2-8432-2d9ac63c43e7",
+                    "name" : "matroska",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Format Group",
+                  "fileFormats" : [ {
+                    "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                    "name" : "fmt/569",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                }, {
+                  "id" : {
+                    "guid" : "402dbdaf-92c9-5d4f-adb0-aeb787a692b3",
+                    "name" : "container",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Content Type",
+                  "fileFormats" : [ {
+                    "guid" : "ac5ed58c-9059-57d4-ad58-a7206d5fbf12",
+                    "name" : "fmt/1071",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "da90e482-2c08-57b9-ac63-6ef3c2837ca8",
+                    "name" : "fmt/1087",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "fbf38e85-1980-5bb9-be01-1a15d99eb817",
+                    "name" : "fmt/289",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "ce998789-ec87-527e-a76d-9c6767fd4adb",
+                    "name" : "fmt/410",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "0897d6a7-a4c7-5869-8ed0-add85047fcd0",
+                    "name" : "fmt/411",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "d67def5c-a7a8-522a-a193-b76d8c3c77b3",
+                    "name" : "fmt/468",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "607c448a-3778-5445-b70f-ddce7d6e84a9",
+                    "name" : "fmt/484",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c3494448-8509-5728-ac7c-f1e8d6150729",
+                    "name" : "fmt/625",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9748cefb-43f7-5d88-aef5-eb5f6e52cf36",
+                    "name" : "TSS-fmt/2",
+                    "namespace" : "http://tessella.com"
+                  }, {
+                    "guid" : "76d0b902-f0c6-5960-b581-be2a3c9d825f",
+                    "name" : "x-fmt/219",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c2955350-56f8-5198-9193-777f0c022168",
+                    "name" : "x-fmt/263",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "7fe92564-d680-5656-9239-2b54ce2664e1",
+                    "name" : "x-fmt/264",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "de799ae7-7ae5-5efd-88b9-ac36532a8bde",
+                    "name" : "x-fmt/265",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "3d063d8a-4a5a-584c-858f-e476436153bf",
+                    "name" : "x-fmt/266",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "010115c8-2844-54d8-a61b-88b89b8694a4",
+                    "name" : "x-fmt/267",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c0b77a9d-919b-5657-9e98-186fc81d2348",
+                    "name" : "x-fmt/268",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "76d983f6-1aef-5cc2-941c-32778c3dd241",
+                    "name" : "x-fmt/412",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamilies'
+      summary: Get Format Families
+      tags:
+        - /format-families
+    post:
+      consumes: []
+      description: Creates a new Format Family and returns the family as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FormatFamily'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Format Family
+      tags:
+        - /format-families
+  /format-families/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Format Family successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Format Family
+      tags:
+        - /format-families
+    get:
+      consumes: []
+      description: Returns the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '404':
+          description: >-
+            If the specified guid does not reference a Format Family known to
+            this registry.
+      summary: Get a Format Family
+      tags:
+        - /format-families
+    put:
+      consumes: []
+      description: >-
+        Updates the Format Family specified by the GUID of the PAR Identifier
+        and returns the family as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FormatFamily'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Format Family
+      tags:
+        - /format-families
+  /preservation-action-types:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Preservation Action Types that match all of the
+        filter conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Preservation Action Types modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Preservation Action Types that are
+            identified by one of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Action Types whose local
+            last modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Action Types whose local
+            last modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Preservation Action Type to return from the start of the list
+            of all matching Preservation Action Types.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Preservation Action Types to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "5f0fbe10-deec-5965-abbb-2474a857a39f",
+                    "name" : "fix",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "fixity check"
+                }, {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionTypes'
+      summary: Get Preservation Action Types
+      tags:
+        - /preservation-action-types
+    post:
+      consumes: []
+      description: Creates a new Preservation Action Type and returns the type as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Preservation Action Type
+      tags:
+        - /preservation-action-types
+  /preservation-action-types/{guid}:
+    delete:
+      consumes: []
+      description: >-
+        Deletes the Preservation Action Type specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Preservation Action Type successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Preservation Action Type
+      tags:
+        - /preservation-action-types
+    get:
+      consumes: []
+      description: >-
+        Returns the Preservation Action Type specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '404':
+          description: >-
+            If the specified guid does not reference a Preservation Action Type
+            known to this registry.
+      summary: Get a Preservation Action Type
+      tags:
+        - /preservation-action-types
+    put:
+      consumes: []
+      description: >-
+        Updates the Preservation Action Type specified by the GUID of the PAR
+        Identifier and returns the type as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Preservation Action Type
+      tags:
+        - /preservation-action-types
+  /preservation-actions:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Preservation Actions that match all of the filter
+        conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Preservation Actions modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Preservation Actions of one of the listed
+            types of action.
+          in: header
+          name: preservation-action-type
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Tools. This filter matches only
+            those Preservation Actions that use one of the listed tools.
+          in: header
+          name: tool
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Preservation Actions. This filter
+            matches only those Preservation Actions that are identified by one
+            of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Actions whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Actions whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Preservation Action to return from the start of the list of
+            all matching Preservation Actions.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Preservation Actions to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "preservationActions" : [ {
+                  "description" : "Property Extraction of video files using MediaInfo CLI and EBUCore Metadata",
+                  "example" : "mediainfo --Output=EBUCore ${inputfile}",
+                  "id" : {
+                    "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                    "name" : "video-extract-mediainfo",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Generate output in EBUCore XML format",
+                    "type" : "command_line",
+                    "value" : "--Output=EBUCore"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  } ],
+                  "outputProperties" : [ {
+                    "description" : "Video Width",
+                    "name" : "Video Width",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                        "name" : "prp/3",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Width"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:width",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Video Height",
+                    "name" : "Video Height",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                        "name" : "prp/4",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Height"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:height",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Colour Space",
+                    "name" : "Colour Space",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                        "name" : "prp/5",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Colour Space"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"ColorSpace\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Bit Depth",
+                    "name" : "Bit Depth",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                        "name" : "prp/9",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "rate",
+                      "description" : "Bits Per Sample"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"BitDepth\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Bit Depth",
+                    "name" : "Bit Depth",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                        "name" : "prp/9",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "rate",
+                      "description" : "Bits Per Sample"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:sampleSize",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Sampling Frequency",
+                    "name" : "Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b34f92b5-e549-5f3d-95a3-02ba0befc875",
+                        "name" : "prp/12",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "description" : "Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:samplingRate",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Creation Date",
+                    "name" : "Creation Date",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                        "name" : "prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "date",
+                      "description" : "Creation Date"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:dateCreated"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingApplication\"]"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Language",
+                    "name" : "Language",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "1e547c8a-7237-5da7-b4e8-60df45515f89",
+                        "name" : "prp/24",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Language"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioTrack/@trackLanguage",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Duration",
+                    "name" : "Duration",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bf17b78e-365d-52d0-881a-42a31e2f60eb",
+                        "name" : "prp/10002",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "size",
+                      "description" : "Length In Seconds"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:duration/ebucore:normalPlayTime/substring(., 3)"
+                  }, {
+                    "description" : "Number of Audio Channels",
+                    "name" : "Number of Audio Channels",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "df6dd369-a2b8-5fae-9a25-396dd040863a",
+                        "name" : "prp/10003",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Audio Channels"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:channels",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Bitrate Is Variable",
+                    "name" : "Bitrate Is Variable",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                        "name" : "prp/10004",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "boolean",
+                      "class" : "other",
+                      "description" : "Bitrate Is Variable"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Bitrate Is Variable",
+                    "name" : "Bitrate Is Variable",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                        "name" : "prp/10004",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "boolean",
+                      "class" : "other",
+                      "description" : "Bitrate Is Variable"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Audio Bitrate",
+                    "name" : "Audio Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRate",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Video Bitrate",
+                    "name" : "Video Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRate",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Overall Bitrate",
+                    "name" : "Overall Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"OverallBitRate\"]"
+                  }, {
+                    "description" : "Encoding Type",
+                    "name" : "Encoding Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                        "name" : "prp/10006",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Encoding Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:videoEncoding/@typeLabel",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Encoding Type",
+                    "name" : "Encoding Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                        "name" : "prp/10006",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Encoding Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioEncoding/@typeLabel",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Number Of Video Streams",
+                    "name" : "Number Of Video Streams",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                        "name" : "prp/10008",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Streams"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:videoFormat)"
+                  }, {
+                    "description" : "Number Of Audio Streams",
+                    "name" : "Number Of Audio Streams",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                        "name" : "prp/10008",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Streams"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:audioFormat)"
+                  }, {
+                    "description" : "Frame Rate",
+                    "name" : "Frame Rate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "8e7ccea1-b280-537e-8054-b790a0700b25",
+                        "name" : "prp/10009",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "description" : "Frames Per Second"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:frameRate",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Horizontal Aspect Ratio",
+                    "name" : "Horizontal Aspect Ratio",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                        "name" : "prp/10011",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aspect Ratio"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorNumerator",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Vertical Aspect Ratio",
+                    "name" : "Vertical Aspect Ratio",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                        "name" : "prp/10011",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aspect Ratio"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorDenominator",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Max Audio Bitrate",
+                    "name" : "Max Audio Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                        "name" : "prp/10012",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Max Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRateMax",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Max Video Bitrate",
+                    "name" : "Max Video Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                        "name" : "prp/10012",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Max Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRateMax",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Codec Name",
+                    "name" : "Codec Name",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                        "name" : "TSS-prp/10",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Commercial Codec Name"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/@videoFormatName",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Codec Name",
+                    "name" : "Codec Name",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                        "name" : "TSS-prp/10",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Commercial Codec Name"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/@audioFormatName",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Format Profile",
+                    "name" : "Format Profile",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "96456871-2f91-508f-aeb1-1dfe5d468bba",
+                        "name" : "TSS-prp/11",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Format Profile"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"FormatProfile\"]"
+                  }, {
+                    "description" : "Chroma Sampling",
+                    "name" : "Chroma Sampling",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "5c49dab0-d830-5249-999e-41f5eeaba76e",
+                        "name" : "TSS-prp/39",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Chroma Sampling"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"FormatProfile\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Scan Type",
+                    "name" : "Scan Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "4d94d78b-eade-508f-94e2-9a15c2b2d5de",
+                        "name" : "TSS-prp/40",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Scan Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:scanningFormat",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Timecode Start",
+                    "name" : "Timecode Start",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "21f9b9f6-b380-5841-a4e0-b08b7cbd4cec",
+                        "name" : "TSS-prp/41",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Timecode"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:timecodeFormat/ebucore:timecodeStart/ebucore:timecode",
+                    "groupLabel" : "Timecode",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:timecodeFormat/count(preceding-sibling::ebucore:timecodeFormat)"
+                  } ],
+                  "rawOutputs" : [ {
+                    "description" : "Raw EBUCore output from the tool",
+                    "name" : "EBUCore"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                      "name" : "mediainfo-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "mediainfo",
+                    "toolName" : "MediaInfo CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "MediaArea - https://mediaarea.net",
+                    "toolVersion" : "18.12-1"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  }
+                }, {
+                  "description" : "Migrate to Web Ready MP4 using FFMPEG",
+                  "example" : "ffmpeg -i ${inputfile} -movflags -ab 128k -acodec aac -vb 500k -vcodec libx264 -maxrate 500k -profile:v high -threads 0 -preset slow -bufsize 1000k -pix_fmt yuv420p ${outputfile}",
+                  "id" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "migrate-to-web-ready-mp4-ffmpeg",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile.$ext"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Input file",
+                    "type" : "command_line",
+                    "value" : "-i"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  }, {
+                    "description" : "MOOV Metadata Position Specifier",
+                    "type" : "command_line",
+                    "value" : "-movflags"
+                  }, {
+                    "description" : "Move MOOV metadata to start",
+                    "type" : "command_line",
+                    "value" : "faststart"
+                  }, {
+                    "description" : "Audio Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-ab"
+                  }, {
+                    "description" : "Audio Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "128k"
+                  }, {
+                    "description" : "Audio Codec Specifier",
+                    "type" : "command_line",
+                    "value" : "-acodec"
+                  }, {
+                    "description" : "Audio Codec Value",
+                    "type" : "command_line",
+                    "value" : "aac"
+                  }, {
+                    "description" : "Video Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-vb"
+                  }, {
+                    "description" : "Video Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "500k"
+                  }, {
+                    "description" : "Video Codec Specifier",
+                    "type" : "command_line",
+                    "value" : "-vcodec"
+                  }, {
+                    "description" : "Video Codec Value",
+                    "type" : "command_line",
+                    "value" : "libx264"
+                  }, {
+                    "description" : "Maximum Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-maxrate"
+                  }, {
+                    "description" : "Maximum Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "500k"
+                  }, {
+                    "description" : "Video Profile Specifier",
+                    "type" : "command_line",
+                    "value" : "-profile:v"
+                  }, {
+                    "description" : "Video Profile Value",
+                    "type" : "command_line",
+                    "value" : "high"
+                  }, {
+                    "description" : "Thread Control Specifier",
+                    "type" : "command_line",
+                    "value" : "-threads"
+                  }, {
+                    "description" : "Thread Control Value",
+                    "type" : "command_line",
+                    "value" : "0"
+                  }, {
+                    "description" : "Encoding Speed to Compression Rate Preset Specifier",
+                    "type" : "command_line",
+                    "value" : "-preset"
+                  }, {
+                    "description" : "Encoding Speed to Compression Rate Preset Value",
+                    "type" : "command_line",
+                    "value" : "slow"
+                  }, {
+                    "description" : "Buffer Size Specifier",
+                    "type" : "command_line",
+                    "value" : "-bufsize"
+                  }, {
+                    "description" : "Buffer Size Value",
+                    "type" : "command_line",
+                    "value" : "1000k"
+                  }, {
+                    "description" : "Pixel Format Specifier",
+                    "type" : "command_line",
+                    "value" : "-pix_fmt"
+                  }, {
+                    "description" : "Pixel Format Value",
+                    "type" : "command_line",
+                    "value" : "yuv420p"
+                  }, {
+                    "description" : "Output file name",
+                    "type" : "command_line",
+                    "value" : "${outputfile}"
+                  } ],
+                  "outputFiles" : [ {
+                    "description" : "File that will be created",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile.mp4"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "a2e3e12e-6b2a-551f-b0af-b3ba71e71754",
+                      "name" : "ffmpeg-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "ffmpeg",
+                    "toolName" : "FFMPEG CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "FFMPEG - https://www.ffmpeg.org/",
+                    "toolVersion" : "3.1.4"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                      "name" : "mig",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "migration"
+                  }
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/PreservationActions'
+      summary: Get Preservation Actions
+      tags:
+        - /preservation-actions
+    post:
+      consumes: []
+      description: Creates a new Preservation Action and returns the action as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationAction'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Preservation Action
+      tags:
+        - /preservation-actions
+  /preservation-actions/{guid}:
+    delete:
+      consumes: []
+      description: >-
+        Deletes the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Preservation Action successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Preservation Action
+      tags:
+        - /preservation-actions
+    get:
+      consumes: []
+      description: >-
+        Returns the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '404':
+          description: >-
+            If the specified guid does not reference a Preservation Action known
+            to this registry.
+      summary: Get a Preservation Action
+      tags:
+        - /preservation-actions
+    put:
+      consumes: []
+      description: >-
+        Updates the Preservation Action specified by the GUID of the PAR
+        Identifier and returns the action as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationAction'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Preservation Action
+      tags:
+        - /preservation-actions
+  /properties:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Properties that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Properties modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Properties. This filter matches
+            only those Properties that are identified by one of the listed
+            GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Properties whose local last modified
+            date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Properties whose local last modified
+            date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Property to return from the start of the list of all matching
+            Properties.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Properties to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "parProperties" : [ {
+                  "id" : {
+                    "guid" : "e21641c7-ea11-5f10-9a00-64a7b62d2b95",
+                    "name" : "prp/10",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "integer",
+                  "class" : "rate",
+                  "description" : "Samples Per Pixel"
+                }, {
+                  "id" : {
+                    "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                    "name" : "prp/5",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "string",
+                  "class" : "other",
+                  "description" : "Colour Space"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/ParProperties'
+      summary: Get Properties
+      tags:
+        - /properties
+    post:
+      consumes: []
+      description: Creates a new Property and returns the property as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/ParProperty'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Property
+      tags:
+        - /properties
+  /properties/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Property specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Property successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Property
+      tags:
+        - /properties
+    get:
+      consumes: []
+      description: Returns the Property specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '404':
+          description: >-
+            If the specified guid does not reference a Property known to this
+            registry.
+      summary: Get a Property
+      tags:
+        - /properties
+    put:
+      consumes: []
+      description: >-
+        Updates the Property specified by the GUID of the PAR Identifier and
+        returns the property as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/ParProperty'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Property
+      tags:
+        - /properties
+  /representation-formats:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Representation Formats that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+        
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any RepresentationFormats modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Representation Formats. This filter matches
+            only those Representation Formats that are identified by one of the listed
+            GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Representation Formats whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Representation Formats whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first RepresentationFormat to return from the start of the list of all
+            matching Representation Formats.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of RepresentationFormats to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "representationFormats" : [{
+                  "id": {
+                    "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                    "name": "repfmt/1",
+                    "namespace": "http://par.preservica.com"
+                  },
+                  "name": "Email",
+                  "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                  "representationFormatSignature": {
+                    "primaryFileCriteria": [
+                      {
+                        "formatFamilies": [
+                          {
+                            "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                            "name": "email",
+                            "namespace": "http://par.preservica.com"
+                          }
+                        ]
+                      }
+                    ],
+                    "fileCriteria": [
+                      {
+                        "minimum": "0",
+                        "maximum": "unbounded"
+                      }
+                    ]
+                  }
+                },{
+                  "id": {
+                    "guid": "b7ad4e34-304e-5b41-959f-9afb9fe5cd70",
+                    "name": "repfmt/2",
+                    "namespace": "http://par.preservica.com"
+                  },
+                  "name": "Tweet",
+                  "description": "A Tweet is described by a primary Tweet JSON file. This file may reference up to 4 jpg or png images and up to 1 MP4 video.",
+                  "representationFormatSignature": {
+                    "primaryFileCriteria": [
+                      {
+                        "formats": [
+                          {
+                            "guid": "61370fce-f770-5018-9d6d-39bd639c59cb",
+                            "name": "fmt/1311",
+                            "namespace": "http://www.nationalarchives.gov.uk"
+                          }
+                        ]
+                      }
+                    ],
+                    "fileCriteria": [
+                      {
+                        "formatFamilies": [
+                          {
+                            "guid": "7bcc3e4c-4e97-556e-9592-8d7ea62187fa",
+                            "name": "jpeg",
+                            "namespace": "http://par.preservica.com"
+                          },
+                          {
+                            "guid": "b7d2f299-ec03-591e-be30-16b74b599b3d",
+                            "name": "png",
+                            "namespace": "http://par.preservica.com"
+                          }
+                        ],
+                        "minimum": "0",
+                        "maximum": "4"
+                      },
+                      {
+                        "formats": [
+                          {
+                            "guid": "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                            "name": "fmt/199",
+                            "namespace": "http://www.nationalarchives.gov.uk"
+                          }
+                        ],
+                        "minimum": "0",
+                        "maximum": "1"
+                      }
+                    ]
+                  }
+                }]
+              }
+          schema:
+            $ref: '#/definitions/RepresentationFormats'
+      summary: Get Representation Formats
+      tags:
+        - /representation-formats
+  /representation-formats/{guid}:
+    delete:
+        consumes: []
+        description: Deletes the Representation Format specified by the GUID of the PAR Identifier
+        parameters:
+          - in: path
+            name: guid
+            required: true
+            type: string
+          - description: HTTP Basic Auth header
+            in: header
+            name: Authorization
+            required: true
+            type: string
+        produces: []
+        responses:
+          '204':
+            description: Representation Format successfully deleted.
+          '401':
+            description: If no Authorization header has been supplied.
+          '403':
+            description: >-
+              If the supplied Authorization header does not reference a user with
+              write access to this registry.
+        summary: Delete Representation Format
+        tags:
+          - /representation-formats
+    get:
+      consumes: []
+      description: Returns the Representation Format specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id": {
+                  "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                  "name": "repfmt/1",
+                  "namespace": "http://par.preservica.com"
+                },
+                "name": "Email",
+                "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                "representationFormatSignature": {
+                  "primaryFileCriteria": [
+                    {
+                      "formatFamilies": [
+                        {
+                          "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                          "name": "email",
+                          "namespace": "http://par.preservica.com"
+                        }
+                      ]
+                    }
+                  ],
+                  "fileCriteria": [
+                    {
+                      "minimum": "0",
+                      "maximum": "unbounded"
+                    }
+                  ]
+                }
+              }
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+        '404':
+          description: >-
+            If the specified guid does not reference a Representation Format known to this
+            registry.
+      summary: Get a Representation Format
+      tags:
+        - /representation-formats
+    put:
+      consumes: []
+      description: >-
+        Updates the Representation Format specified by the GUID of the PAR Identifier and
+        returns the Representation Format as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Representation Format
+      tags:
+        - /representation-formats
+  /tools:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Tools that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Tools modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Tools. This filter matches only
+            those Tools that are identified by one of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Tools whose local last modified date
+            is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Tools whose local last modified date
+            is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Tool to return from the start of the list of all matching
+            Tools.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Tools to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "tools" : [ {
+                  "id" : {
+                    "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                    "name" : "mediainfo-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "mediainfo",
+                  "toolName" : "MediaInfo CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "MediaArea - https://mediaarea.net",
+                  "toolVersion" : "18.12-1"
+                }, {
+                  "id" : {
+                    "guid" : "efa0ee01-6a6c-5e97-ad47-eb7c08e94ad0",
+                    "name" : "libreoffice-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "soffice",
+                  "toolName" : "LibreOffice CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "The Document Foundation - https://www.libreoffice.org/",
+                  "toolVersion" : "5.3.5.2"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/Tools'
+      summary: Get Tools
+      tags:
+        - /tools
+    post:
+      consumes: []
+      description: Creates a new Tool and returns the tool as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Tool'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Tool
+      tags:
+        - /tools
+  /tools/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Tool specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Tool successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Tool
+      tags:
+        - /tools
+    get:
+      consumes: []
+      description: Returns the Tool specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '404':
+          description: >-
+            If the specified guid does not reference a Tool known to this
+            registry.
+      summary: Get a Tool
+      tags:
+        - /tools
+    put:
+      consumes: []
+      description: >-
+        Updates the Tool specified by the GUID of the PAR Identifier and returns
+        the tool as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Tool'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Tool
+      tags:
+        - /tools
+schemes:
+  - https
+swagger: '2.0'
+tags:
+  - description: Requests relating to PAR Business Rule entities
+    name: /business-rules
+  - description: Endpoints relating to PAR Preservation Action entities
+    name: /preservation-actions
+  - description: Endpoints relating to PAR Tool entities
+    name: /tools
+  - description: Endpoints relating to PAR File Format entities. Note that to support backward compatibility against existing registries, for v1.0, the file-formats endpoint works with the "name" part of the ParIdentifier rather than the "guid" part.
+    name: /file-formats
+  - description: Endpoints relating to PAR Representation Format entities
+    name: /representation-formats
+  - description: Endpoints relating to PAR Property entities
+    name: /properties
+  - description: Endpoints relating to PAR Preservation Action Type Type entities
+    name: /preservation-action-types
+  - description: Endpoints relating to PAR Format Family entities
+    name: /format-families

--- a/docs/api/1.1/index.html
+++ b/docs/api/1.1/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>My New API</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "par-api.yaml", //Location of Open API spec in the repo
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/docs/api/1.1/par-api.yaml
+++ b/docs/api/1.1/par-api.yaml
@@ -1,0 +1,5359 @@
+basePath: /par
+definitions:
+  Action:
+    properties:
+      optionalInputFiles:
+        items:
+          $ref: '#/definitions/InputFile'
+        type: array
+      optionalInputProperties:
+        items:
+          $ref: '#/definitions/InputProperty'
+        type: array
+      outputFilesRetrieved:
+        items:
+          $ref: '#/definitions/OutputFile'
+        type: array
+      outputPropertiesRetrieved:
+        items:
+          $ref: '#/definitions/OutputProperty'
+        type: array
+      preservationAction:
+        $ref: '#/definitions/ParIdentifier'
+      priority:
+        format: int32
+        type: integer
+      rawOutputsRetrieved:
+        items:
+          $ref: '#/definitions/OutputRaw'
+        type: array
+  AuthorInformation:
+    properties:
+      authorCompoundName:
+        type: string
+      authorId:
+        type: string
+      authorIdNamespace:
+        type: string
+      authorName:
+        type: string
+      organisationName:
+        type: string
+  BusinessRule:
+    properties:
+      description:
+        type: string
+      formatFamilies:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      formats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      notes:
+        type: string
+      preservationActionTypes:
+        items:
+          $ref: '#/definitions/PreservationActionType'
+        type: array
+      preservationActions:
+        items:
+          $ref: '#/definitions/Action'
+        type: array
+  BusinessRules:
+    properties:
+      businessRules:
+        items:
+          $ref: '#/definitions/BusinessRule'
+        type: array
+  ByteSequenceInformation:
+    properties:
+      byteSequenceId:
+        type: string
+      byteSequenceIdNamespace:
+        type: string
+      byteSequenceValue:
+        type: string
+      endianness:
+        type: string
+      indirectOffsetLength:
+        type: string
+      indirectOffsetLocation:
+        type: string
+      maxOffset:
+        type: string
+      offset:
+        type: string
+      positionType:
+        type: string
+  DeveloperInformation:
+    properties:
+      developerCompoundName:
+        type: string
+      developerId:
+        type: string
+      developerIdNamespace:
+        type: string
+      developerName:
+        type: string
+      organisationName:
+        type: string
+  DocumentInformation:
+    properties:
+      author:
+        $ref: '#/definitions/AuthorInformation'
+      availabilityDescription:
+        type: string
+      availabilityNote:
+        type: string
+      displayText:
+        type: string
+      documentIPR:
+        type: string
+      documentId:
+        type: string
+      documentIdNamespace:
+        type: string
+      documentNote:
+        type: string
+      documentType:
+        type: string
+      publicationDate:
+        type: string
+      publisher:
+        $ref: '#/definitions/PublisherInformation'
+      titleText:
+        type: string
+  ExternalSignatureInformation:
+    properties:
+      externalSignatureId:
+        type: string
+      externalSignatureIdNamespace:
+        type: string
+      signature:
+        type: string
+      signatureType:
+        type: string
+  FileCriterion:
+    properties:
+      formats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      formatFamilies:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      minimum:
+        type: string
+        description: (representing a number)
+      maximum:
+        type: string
+        description: (representing a number or "unbounded")
+  FileFormat:
+    properties:
+      aliases:
+        items:
+          type: string
+        type: array
+      binaryFileFormat:
+        type: string
+      byteOrders:
+        items:
+          type: string
+        type: array
+      description:
+        type: string
+      developers:
+        items:
+          $ref: '#/definitions/DeveloperInformation'
+        type: array
+      disclosure:
+        type: string
+      documents:
+        items:
+          $ref: '#/definitions/DocumentInformation'
+        type: array
+      externalSignatures:
+        items:
+          $ref: '#/definitions/ExternalSignatureInformation'
+        type: array
+      families:
+        items:
+          type: string
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      identifiers:
+        items:
+          $ref: '#/definitions/IdentifierInformation'
+        type: array
+      internalSignatures:
+        items:
+          $ref: '#/definitions/InternalSignatureInformation'
+        type: array
+      lastUpdatedDate:
+        type: string
+      localLastModifiedDate:
+        type: string
+      name:
+        type: string
+      note:
+        type: string
+      provenance:
+        $ref: '#/definitions/ProvenanceInformation'
+      registryVersions:
+        items:
+          $ref: '#/definitions/RegistryVersionInformation'
+        type: array
+      relatedFormats:
+        items:
+          $ref: '#/definitions/RelatedFormatInformation'
+        type: array
+      releaseDate:
+        type: string
+      risk:
+        type: string
+      technicalEnvironment:
+        type: string
+      types:
+        items:
+          type: string
+        type: array
+      version:
+        type: string
+      withdrawnDate:
+        type: string
+  FileFormats:
+    properties:
+      fileFormats:
+        items:
+          $ref: '#/definitions/FileFormat'
+        type: array
+  FormatFamilies:
+    properties:
+      formatFamilies:
+        items:
+          $ref: '#/definitions/FormatFamily'
+        type: array
+  FormatFamily:
+    properties:
+      familyType:
+        type: string
+      fileFormats:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      formatFamilies:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+  IdentifierInformation:
+    properties:
+      identifier:
+        type: string
+      identifierType:
+        type: string
+  InputFile:
+    properties:
+      description:
+        type: string
+      file:
+        $ref: '#/definitions/ParFile'
+      name:
+        type: string
+  InputProperty:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      parProperty:
+        $ref: '#/definitions/ParProperty'
+  InputToolArgument:
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+      value:
+        type: string
+  InternalSignatureInformation:
+    properties:
+      byteSequences:
+        items:
+          $ref: '#/definitions/ByteSequenceInformation'
+        type: array
+      signatureId:
+        type: string
+      signatureIdNamespace:
+        type: string
+      signatureName:
+        type: string
+      signatureNote:
+        type: string
+  OutputFile:
+    properties:
+      description:
+        type: string
+      file:
+        $ref: '#/definitions/ParFile'
+      name:
+        type: string
+  OutputProperty:
+    properties:
+      description:
+        type: string
+      groupIdBinding:
+        type: string
+      groupLabel:
+        type: string
+      name:
+        type: string
+      parProperty:
+        $ref: '#/definitions/ParProperty'
+      toolBinding:
+        type: string
+  OutputRaw:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      value:
+        type: string
+  ParFile:
+    properties:
+      filepath:
+        type: string
+  ParIdentifier:
+    properties:
+      guid:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+  ParProperties:
+    properties:
+      parProperties:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+  ParProperty:
+    properties:
+      class:
+        type: string
+      description:
+        type: string
+      equivalentTo:
+        items:
+          type: string
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      type:
+        type: string
+      units:
+        type: string
+      value:
+        type: string
+  PreservationAction:
+    properties:
+      constraints:
+        items:
+          $ref: '#/definitions/PreservationActionConstraints'
+        type: array
+      description:
+        type: string
+      example:
+        type: string
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      inputFiles:
+        items:
+          $ref: '#/definitions/InputFile'
+        type: array
+      inputProperties:
+        items:
+          $ref: '#/definitions/InputProperty'
+        type: array
+      inputToolArguments:
+        items:
+          $ref: '#/definitions/InputToolArgument'
+        type: array
+      localLastModifiedDate:
+        type: string
+      outputFiles:
+        items:
+          $ref: '#/definitions/OutputFile'
+        type: array
+      outputProperties:
+        items:
+          $ref: '#/definitions/OutputProperty'
+        type: array
+      rawOutputs:
+        items:
+          $ref: '#/definitions/OutputRaw'
+        type: array
+      tool:
+        $ref: '#/definitions/Tool'
+      type:
+        $ref: '#/definitions/PreservationActionType'
+  PreservationActionConstraints:
+    properties:
+      allowedFormats:
+        items:
+          $ref: '#/definitions/FileFormat'
+        type: array
+      allowedPropertiesAllOf:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+      allowedPropertiesAnyOf:
+        items:
+          $ref: '#/definitions/ParProperty'
+        type: array
+      inputItemName:
+        type: string
+  PreservationActionType:
+    properties:
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      label:
+        type: string
+      localLastModifiedDate:
+        type: string
+  PreservationActionTypes:
+    properties:
+      preservationActionTypes:
+        items:
+          $ref: '#/definitions/PreservationActionType'
+        type: array
+  PreservationActions:
+    properties:
+      preservationActions:
+        items:
+          $ref: '#/definitions/PreservationAction'
+        type: array
+  ProvenanceInformation:
+    properties:
+      provenanceDescription:
+        type: string
+      provenanceName:
+        type: string
+      provenanceSourceDate:
+        type: string
+      provenanceSourceId:
+        type: string
+      provenanceSourceNamespace:
+        type: string
+  PublisherInformation:
+    properties:
+      organisationName:
+        type: string
+      publisherCompoundName:
+        type: string
+      publisherId:
+        type: string
+      publisherIdNamespace:
+        type: string
+      publisherName:
+        type: string
+  RegistryVersionInformation:
+    properties:
+      name:
+        type: string
+      registryNamespace:
+        type: string
+      version:
+        type: string
+  RelatedFormatInformation:
+    properties:
+      relatedFormatId:
+        type: string
+      relatedFormatIdNamespace:
+        type: string
+      relatedFormatName:
+        type: string
+      relatedFormatVersion:
+        type: string
+      relationshipType:
+        type: string
+  RepresentationFormat:
+    properties:
+      description:
+        type: string
+      hasPriorityOver:
+        items:
+          $ref: '#/definitions/ParIdentifier'
+        type: array
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      name:
+        type: string
+      representationFormatSignature:
+        $ref: '#/definitions/RepresentationFormatSignature'
+  RepresentationFormats:
+    properties:
+      representationFormats:
+        items:
+          $ref: '#/definitions/RepresentationFormat'
+        type: array
+  RepresentationFormatSignature:
+    properties:
+      fileCriteria:
+        items:
+          $ref: '#/definitions/FileCriterion'
+        type:
+          array
+      primaryFileCriteria:
+        items:
+          $ref: '#/definitions/FileCriterion'
+        type:
+          array
+  Tool:
+    properties:
+      id:
+        $ref: '#/definitions/ParIdentifier'
+      localLastModifiedDate:
+        type: string
+      toolAcceptedParameters:
+        items:
+          type: string
+        type: array
+      toolLabel:
+        type: string
+      toolName:
+        type: string
+      toolOperatingEnvironments:
+        items:
+          type: string
+        type: array
+      toolPublisher:
+        type: string
+      toolVersion:
+        type: string
+  Tools:
+    properties:
+      tools:
+        items:
+          $ref: '#/definitions/Tool'
+        type: array
+host: parcore.org
+info:
+  description: >-
+    API to retrieve and update Business Rules, Preservation Actions etc from a
+    Preservation Action Registries compliant endpoint
+  title: PAR API
+  version: '1.1'
+paths:
+  /business-rules:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Business Rules that match all of the filter
+        conditions supplied. Any number of fitlers can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Business Rules modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Actions. This
+            filter matches only those Business Rules whose purpose is to perform
+            one of the listed actions.
+          in: header
+          name: preservation-action-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Preservation Actions. This
+            filter matches only those Business Rules whose purpose is to perform
+            one of the listed actions.
+          in: header
+          name: preservation-action-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Business Rules whose purpose is to perform
+            one of the listed types of action.
+          in: header
+          name: preservation-action-type-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of name of Preservation Action Types. This
+            filter matches only those Business Rules whose purpose is to perform
+            one of the listed types of action.
+          in: header
+          name: preservation-action-type-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of file formats. This filter matches 
+            only those Business Rules that have been defined to apply to one of 
+            the listed formats. This includes formats where the rule is 
+            applicable indirectly through the format family.
+          in: header
+          name: file-format-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of file formats. This filter matches 
+            only those Business Rules that have been defined to apply to one of 
+            the listed formats. This includes formats where the rule is 
+            applicable indirectly through the format family.
+          in: header
+          name: file-format-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of formats families. This filter 
+            matches only those Business Rules that have been defined to apply to 
+            one of the listed format families. 
+          in: header
+          name: format-family-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of formats families. This filter 
+            matches only those Business Rules that have been defined to apply to 
+            one of the listed format families. 
+          in: header
+          name: format-family-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Business Rules. This filter
+            matches only those Business Rules that are identified by one of the
+            listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Business Rules. This filter
+            matches only those Business Rules that are identified by one of the
+            listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Business Rules whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Business Rules whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Business Rule to return from the start of the list of all
+            matching Business Rules.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Business Rules to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "businessRules" : [ {
+                  "id" : {
+                    "guid" : "cb2bea88-8006-58fa-a395-dcf0d76a32ee",
+                    "name" : "mediainfo-extraction-of-video",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "For property extraction of Video file formats, use the MediaInfo CLI",
+                  "formats" : [ {
+                    "guid" : "6590d828-10ac-5aa4-aaf8-36f073343432",
+                    "name" : "fmt/735",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "e534e808-9680-5945-8046-5fface23cd93",
+                    "name" : "fmt/951",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "84dbb5f7-b722-5817-8762-e05c1ef17759",
+                    "name" : "fmt/973",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "993a1df3-7da3-5972-b765-431195b3f009",
+                    "name" : "fmt/1086",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "61a35b4f-34c0-51b4-9dd3-8f03c79b69a8",
+                    "name" : "x-fmt/139",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9fdb2a8d-3143-54c1-a3ae-83f122b5fd4c",
+                    "name" : "x-fmt/419",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "formatFamilies" : [ {
+                    "id" : {
+                      "guid" : "60303765-0d86-5f48-a26c-96daec3b754b",
+                      "name" : "video",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Video File Formats",
+                    "fileFormats" : [ {
+                      "guid" : "dfc92377-0582-584b-9bce-661cc365b10d",
+                      "name" : "TSS-fmt/4",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                      "name" : "fmt/649",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                      "name" : "fmt/506",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f3252fc5-f9fe-5b4f-925e-edc4653a7ff0",
+                      "name" : "fmt/193",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                      "name" : "fmt/786",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                      "name" : "fmt/131",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                      "name" : "fmt/499",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                      "name" : "fmt/133",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                      "name" : "fmt/199",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                      "name" : "fmt/200",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "9947c06d-591e-56bd-98df-8c15a5d38655",
+                      "name" : "TSS-fmt/13",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "cc6f693f-3e92-5e6c-a5f4-dde355f9b498",
+                      "name" : "TSS-fmt/15",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "36ce7b02-d2cb-5d23-bad3-de475d3e8eea",
+                      "name" : "fmt/105",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                      "name" : "x-fmt/385",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "82c41aa8-bf6a-50ba-97b1-d28f3b25d77a",
+                      "name" : "fmt/107",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "eba99ac5-b80b-560f-9d0f-cb371260246d",
+                      "name" : "TSS-fmt/11",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                      "name" : "fmt/109",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "ec00c475-d655-57f0-b2df-aefe8c0c943e",
+                      "name" : "TSS-fmt/9",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                      "name" : "fmt/507",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                      "name" : "fmt/505",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                      "name" : "fmt/945",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                      "name" : "fmt/569",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "80a02837-3b02-5e43-beb8-b8121343da71",
+                      "name" : "fmt/1055",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                      "name" : "fmt/731",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "83e012dd-d83c-577f-982f-07d2e846e93d",
+                      "name" : "fmt/110",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "98bdd321-0f14-5ff8-b174-5470977c4fb4",
+                      "name" : "TSS-fmt/3",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                      "name" : "fmt/5",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                      "name" : "fmt/585",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "e104d7fb-0d2c-55d7-ba89-65cdd41b5be7",
+                      "name" : "fmt/640",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                      "name" : "fmt/573",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "b4471a17-e68e-5979-9299-7e9f78772d89",
+                      "name" : "TSS-fmt/14",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                      "name" : "x-fmt/386",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "2253f81a-8692-5ddd-8010-99c2a2461360",
+                      "name" : "fmt/104",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "2d398b99-4a15-5fb9-93ad-c6dfa86b8d78",
+                      "name" : "TSS-fmt/16",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                      "name" : "fmt/425",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "f92ffa76-ef89-55df-89ef-94bca58e4e2d",
+                      "name" : "TSS-fmt/10",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "3aa32617-a451-5fe2-856f-b5e0e0b5b968",
+                      "name" : "fmt/106",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                      "name" : "fmt/108",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dd86844e-3988-55ac-bc19-43bfe86be1ba",
+                      "name" : "TSS-fmt/12",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                      "name" : "x-fmt/152",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                      "name" : "x-fmt/384",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                      "name" : "x-fmt/190",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                      "name" : "x-fmt/382",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "ae7ebffb-5140-53a6-9a9a-adbe90953f45",
+                      "name" : "asf",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                      "name" : "fmt/131",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                      "name" : "fmt/505",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                      "name" : "fmt/506",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                      "name" : "fmt/507",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "dbd65709-a393-5d73-9b68-0355972532ba",
+                      "name" : "x-fmt/137",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "7c62e0ea-4846-52d4-b62b-ab99d7084d7d",
+                      "name" : "wma",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "eb916390-88b6-5431-b8e3-cf03e44c7554",
+                      "name" : "fmt/132",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "c6c99061-2702-5b83-98fe-e6f46d1c007b",
+                      "name" : "mpeg-audio",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "6efff7b7-3ddb-57ab-85bb-3501ba202afe",
+                      "name" : "fmt/134",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "76a512ae-6c0b-5e11-bf2f-714ffa770ea2",
+                      "name" : "fmt/198",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "984e8161-82c7-5821-9b08-2ed9580b0fd5",
+                      "name" : "fmt/347",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3a7d7cb5-f8f7-5414-b155-f6558cf9e897",
+                      "name" : "x-fmt/279",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "ae87efa4-cd5a-5d07-b1b7-251a4fe871c8",
+                      "name" : "ogg",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "9ba33cd0-6339-5add-9c10-cd9a430a1d84",
+                      "name" : "fmt/203",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                      "name" : "fmt/945",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "98adc483-d0cd-58b4-84d8-0d4117b53089",
+                      "name" : "fmt/946",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "d67128ec-b34b-525a-a228-0c5cf692b22c",
+                      "name" : "fmt/947",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "d04d2361-05d5-582f-a83c-c573f6e34cc1",
+                      "name" : "fmt/948",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                      "name" : "video-extract-mediainfo",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use MediaInfo for Property Extraction"
+                }, {
+                  "id" : {
+                    "guid" : "9396cbc6-03d2-5195-ac8e-05017913defc",
+                    "name" : "property-extraction-of-camera-raw",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "For Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW Images use ExifTool",
+                  "formats" : [ {
+                    "guid" : "026d9445-7056-5824-adf8-0ab7db541319",
+                    "name" : "fmt/202",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "1fff9428-6bf2-5a90-8afd-c560a63d2f33",
+                    "name" : "fmt/642",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "29814d1c-020e-5156-9405-3562137b4295",
+                    "name" : "fmt/668",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4b8cac87-b6ba-57d4-8f4e-02f35ba32c64",
+                    "name" : "fmt/669",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                      "name" : "extract-camera-raw",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use ExifTool for Nikon, Fujifilm, Olympus and Minolta RAW Image Property Extraction"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/BusinessRules'
+      summary: Get Business Rules
+      tags:
+        - /business-rules
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Business Rule and returns the rule as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/BusinessRule'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Business Rule
+      tags:
+        - /business-rules
+  /business-rules/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Business Rule successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Business Rule
+      tags:
+        - /business-rules
+    get:
+      consumes: []
+      description: Returns the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '404':
+          description: >-
+            If the specified guid does not reference a Business Rule known to
+            this registry.
+      summary: Get a Business Rule
+      tags:
+        - /business-rules
+    put:
+      consumes: 
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Business Rule specified by the GUID of the PAR Identifier
+        and returns the rule as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/BusinessRule'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                  "name" : "web-ready-mp4-migration-ffmpeg",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                "formats" : [ {
+                  "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                  "name" : "fmt/5",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                  "name" : "fmt/108",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                  "name" : "fmt/109",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                  "name" : "fmt/131",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                  "name" : "fmt/133",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                  "name" : "fmt/199",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                  "name" : "fmt/200",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                  "name" : "fmt/425",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                  "name" : "fmt/499",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                  "name" : "fmt/573",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                  "name" : "fmt/585",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                  "name" : "fmt/649",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                  "name" : "fmt/731",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                  "name" : "fmt/786",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                  "name" : "fmt/935",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                  "name" : "fmt/945",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                  "name" : "x-fmt/152",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                  "name" : "x-fmt/190",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                  "name" : "x-fmt/382",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                  "name" : "x-fmt/384",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                  "name" : "x-fmt/385",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                  "name" : "x-fmt/386",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                } ],
+                "preservationActions" : [ {
+                  "preservationAction" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "ffmpeg-web-ready-migration",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "priority" : 1
+                } ],
+                "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+              }
+          schema:
+            $ref: '#/definitions/BusinessRule'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Business Rule
+      tags:
+        - /business-rules
+  /file-formats:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of File Formats that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any FileFormats modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of the GUIDs of File Formats. This filter matches
+            only those File Formats that are identified by one of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of the names of File Formats. This filter matches
+            only those File Formats that are identified by one of the listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those File Formats whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those File Formats whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first FileFormat to return from the start of the list of all
+            matching File Formats.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of FileFormats to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "fileFormats" : [ {
+                  "description" : "This is an outline record only, and requires further details, research or authentication to provide information that will enable users to further understand the format and to assess digital preservation risks associated with it if appropriate.",
+                  "externalSignatures" : [ {
+                    "signature" : "f4a",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "m4v",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "m4a",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "f4v",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mp4",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                    "name" : "fmt/199",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/357",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "66747970{0-64}(6D703432|6D703431|69736F6D|69736F32)*6D6F6F76",
+                      "maxOffset" : "0",
+                      "offset" : "4",
+                      "positionType" : "Absolute from BOF"
+                    } ],
+                    "signatureId" : "is/278",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2017-07-05T20:22:48Z",
+                  "name" : "MPEG-4 Media File",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "x-fmt/384",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Quicktime",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/596",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Apple Lossless Audio Codec",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/357",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "3GPP Audio/Video File",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Video" ],
+                  "version" : "\n      "
+                }, {
+                  "description" : "MPEG-2 is a lossy compression standard (an improvement and expansion of the MPEG-1 standard) designed for the generic coding of video and audio and intended to cover a wide scope of application, including: video production, broadcast and editing. Streams are at potentially higher bitrates than MPEG-1 but more efficient compression making it suited to High Definition video. MPEG-2 Video supports both 'progressive' and 'interlaced' frame video. An MPG-2 ‘Program’ stream (PS) file (*.mpg, *.mpeg) generally contain both video and audio streams, generally for synchronised playback, and may carry a variety of other data (e.g. video captions).\n\nSome camcorders store their MPEG-2 Program Stream video data as files with the .mod extension, usually alongside other files containing metadata and management information for the video.",
+                  "externalSignatures" : [ {
+                    "signature" : "mod",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mpeg",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "mpg",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                    "name" : "x-fmt/386",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "identifiers" : [ {
+                    "identifier" : "x-fmt/386",
+                    "identifierType" : "PUID"
+                  }, {
+                    "identifier" : "video/mpeg",
+                    "identifierType" : "MIME"
+                  } ],
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/800",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "000001BA{8-12}000001BB{8-65536}000001B3{8-136}000001B5",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Absolute from BOF"
+                    } ],
+                    "signatureId" : "is/655",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2019-07-30T19:28:46Z",
+                  "name" : "MPEG-2 Program Stream",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "x-fmt/385",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "MPEG-1 Program Stream",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/425",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Video Object File (MPEG-2 subset)",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Video" ],
+                  "version" : "\n      "
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FileFormats'
+      summary: Get File Formats
+      tags:
+        - /file-formats
+    post:
+      consumes: 
+        - application/json;charset=UTF-8 
+      description: Creates a new File Format and returns the fileFormat as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FileFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create File Format
+      tags:
+        - /file-formats
+  /file-formats/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the File Format specified by the Name part of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: File Format successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete File Format
+      tags:
+        - /file-formats
+    get:
+      consumes: []
+      description: Returns the File Format specified by the Name part of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '404':
+          description: >-
+            If the specified name does not reference a File Format known to this
+            registry.
+      summary: Get a File Format
+      tags:
+        - /file-formats
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the File Format specified by the Name part of the PAR Identifier and
+        returns the file format as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FileFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                "externalSignatures" : [ {
+                  "signature" : "wbk",
+                  "signatureType" : "File Extension"
+                }, {
+                  "signature" : "doc",
+                  "signatureType" : "File Extension"
+                } ],
+                "id" : {
+                  "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                  "name" : "fmt/40",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                },
+                "identifiers" : [ {
+                  "identifier" : "fmt/40",
+                  "identifierType" : "PUID"
+                }, {
+                  "identifier" : "application/msword",
+                  "identifierType" : "MIME"
+                } ],
+                "internalSignatures" : [ {
+                  "byteSequences" : [ {
+                    "byteSequenceId" : "bs/223",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  }, {
+                    "byteSequenceId" : "bs/222",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Absolute from BOF"
+                  }, {
+                    "byteSequenceId" : "bs/224",
+                    "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                    "maxOffset" : "0",
+                    "offset" : "0",
+                    "positionType" : "Variable"
+                  } ],
+                  "signatureId" : "is/182",
+                  "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                } ],
+                "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                "name" : "Microsoft Word Document",
+                "relatedFormats" : [ {
+                  "relatedFormatId" : "fmt/39",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document",
+                  "relatedFormatVersion" : "6.0/95",
+                  "relationshipType" : "Is subsequent version of"
+                }, {
+                  "relatedFormatId" : "fmt/609",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word (Generic)",
+                  "relatedFormatVersion" : "6.0-2003",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "fmt/111",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "OLE2 Compound Document Format",
+                  "relatedFormatVersion" : "\n      ",
+                  "relationshipType" : "Has priority over"
+                }, {
+                  "relatedFormatId" : "x-fmt/45",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/755",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                }, {
+                  "relatedFormatId" : "fmt/754",
+                  "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                  "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                  "relatedFormatVersion" : "97-2003",
+                  "relationshipType" : "Has lower priority than"
+                } ],
+                "types" : [ "Document" ],
+                "version" : "97-2003"
+              }
+          schema:
+            $ref: '#/definitions/FileFormat'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update File Format
+      tags:
+        - /file-formats
+  /format-families:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Format Families that match all of the filter
+        conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Format Families modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of guids of file formats (i.e. fmt/1,
+            x-fmt/2. This filter matches only those Format Families that include
+            any of the specified formats.
+          in: header
+          name: file-format-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of file formats. This filter matches
+            only those Format Families that include any of the specified formats.
+          in: header
+          name: file-format-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Format Families. This filter
+            matches only those Format Families that are identified by one of the
+            listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Format Families. This filter
+            matches only those Format Families that are identified by one of the
+            listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Format Families whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Format Families whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Format Family to return from the start of the list of all
+            matching Format Families.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Format Families to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "formatFamilies" : [ {
+                  "id" : {
+                    "guid" : "d7df91be-c3d1-51f2-8432-2d9ac63c43e7",
+                    "name" : "matroska",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Format Group",
+                  "fileFormats" : [ {
+                    "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                    "name" : "fmt/569",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                }, {
+                  "id" : {
+                    "guid" : "402dbdaf-92c9-5d4f-adb0-aeb787a692b3",
+                    "name" : "container",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Content Type",
+                  "fileFormats" : [ {
+                    "guid" : "ac5ed58c-9059-57d4-ad58-a7206d5fbf12",
+                    "name" : "fmt/1071",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "da90e482-2c08-57b9-ac63-6ef3c2837ca8",
+                    "name" : "fmt/1087",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "fbf38e85-1980-5bb9-be01-1a15d99eb817",
+                    "name" : "fmt/289",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "ce998789-ec87-527e-a76d-9c6767fd4adb",
+                    "name" : "fmt/410",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "0897d6a7-a4c7-5869-8ed0-add85047fcd0",
+                    "name" : "fmt/411",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "d67def5c-a7a8-522a-a193-b76d8c3c77b3",
+                    "name" : "fmt/468",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "607c448a-3778-5445-b70f-ddce7d6e84a9",
+                    "name" : "fmt/484",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c3494448-8509-5728-ac7c-f1e8d6150729",
+                    "name" : "fmt/625",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9748cefb-43f7-5d88-aef5-eb5f6e52cf36",
+                    "name" : "TSS-fmt/2",
+                    "namespace" : "http://tessella.com"
+                  }, {
+                    "guid" : "76d0b902-f0c6-5960-b581-be2a3c9d825f",
+                    "name" : "x-fmt/219",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c2955350-56f8-5198-9193-777f0c022168",
+                    "name" : "x-fmt/263",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "7fe92564-d680-5656-9239-2b54ce2664e1",
+                    "name" : "x-fmt/264",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "de799ae7-7ae5-5efd-88b9-ac36532a8bde",
+                    "name" : "x-fmt/265",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "3d063d8a-4a5a-584c-858f-e476436153bf",
+                    "name" : "x-fmt/266",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "010115c8-2844-54d8-a61b-88b89b8694a4",
+                    "name" : "x-fmt/267",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "c0b77a9d-919b-5657-9e98-186fc81d2348",
+                    "name" : "x-fmt/268",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "76d983f6-1aef-5cc2-941c-32778c3dd241",
+                    "name" : "x-fmt/412",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamilies'
+      summary: Get Format Families
+      tags:
+        - /format-families
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Format Family and returns the family as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FormatFamily'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Format Family
+      tags:
+        - /format-families
+  /format-families/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Format Family successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Format Family
+      tags:
+        - /format-families
+    get:
+      consumes: []
+      description: Returns the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '404':
+          description: >-
+            If the specified guid does not reference a Format Family known to
+            this registry.
+      summary: Get a Format Family
+      tags:
+        - /format-families
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Format Family specified by the GUID of the PAR Identifier
+        and returns the family as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/FormatFamily'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                  "name" : "ooxmltypes",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "familyType" : "Open Office XML Formats",
+                "fileFormats" : [ {
+                  "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                  "name" : "fmt/214",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                  "name" : "fmt/412",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                  "name" : "fmt/215",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                  "name" : "fmt/599",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                }, {
+                  "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                  "name" : "fmt/629",
+                  "namespace" : "http://www.nationalarchives.gov.uk"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/FormatFamily'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Format Family
+      tags:
+        - /format-families
+  /preservation-action-types:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Preservation Action Types that match all of the
+        filter conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Preservation Action Types modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Preservation Action Types that are
+            identified by one of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Preservation Action Types. This
+            filter matches only those Preservation Action Types that are
+            identified by one of the listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Action Types whose local
+            last modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Action Types whose local
+            last modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Preservation Action Type to return from the start of the list
+            of all matching Preservation Action Types.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Preservation Action Types to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "preservationActionTypes" : [ {
+                  "id" : {
+                    "guid" : "5f0fbe10-deec-5965-abbb-2474a857a39f",
+                    "name" : "fix",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "fixity check"
+                }, {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionTypes'
+      summary: Get Preservation Action Types
+      tags:
+        - /preservation-action-types
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Preservation Action Type and returns the type as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Preservation Action Type
+      tags:
+        - /preservation-action-types
+  /preservation-action-types/{guid}:
+    delete:
+      consumes: []
+      description: >-
+        Deletes the Preservation Action Type specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Preservation Action Type successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Preservation Action Type
+      tags:
+        - /preservation-action-types
+    get:
+      consumes: []
+      description: >-
+        Returns the Preservation Action Type specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '404':
+          description: >-
+            If the specified guid does not reference a Preservation Action Type
+            known to this registry.
+      summary: Get a Preservation Action Type
+      tags:
+        - /preservation-action-types
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Preservation Action Type specified by the GUID of the PAR
+        Identifier and returns the type as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                  "name" : "mig",
+                  "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                },
+                "label" : "migration"
+              }
+          schema:
+            $ref: '#/definitions/PreservationActionType'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Preservation Action Type
+      tags:
+        - /preservation-action-types
+  /preservation-actions:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Preservation Actions that match all of the filter
+        conditions supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Preservation Actions modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Preservation Action Types. This
+            filter matches only those Preservation Actions of one of the listed
+            types of action.
+          in: header
+          name: preservation-action-type-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Preservation Action Types. This
+            filter matches only those Preservation Actions of one of the listed
+            types of action.
+          in: header
+          name: preservation-action-type-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Tools. This filter matches only
+            those Preservation Actions that use one of the listed tools.
+          in: header
+          name: tool-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Tools. This filter matches only
+            those Preservation Actions that use one of the listed tools.
+          in: header
+          name: tool-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Preservation Actions. This filter
+            matches only those Preservation Actions that are identified by one
+            of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Preservation Actions. This filter
+            matches only those Preservation Actions that are identified by one
+            of the listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Actions whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Preservation Actions whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Preservation Action to return from the start of the list of
+            all matching Preservation Actions.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Preservation Actions to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "preservationActions" : [ {
+                  "description" : "Property Extraction of video files using MediaInfo CLI and EBUCore Metadata",
+                  "example" : "mediainfo --Output=EBUCore ${inputfile}",
+                  "id" : {
+                    "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                    "name" : "video-extract-mediainfo",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Generate output in EBUCore XML format",
+                    "type" : "command_line",
+                    "value" : "--Output=EBUCore"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  } ],
+                  "outputProperties" : [ {
+                    "description" : "Video Width",
+                    "name" : "Video Width",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                        "name" : "prp/3",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Width"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:width",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Video Height",
+                    "name" : "Video Height",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                        "name" : "prp/4",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Height"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:height",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Colour Space",
+                    "name" : "Colour Space",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                        "name" : "prp/5",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Colour Space"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"ColorSpace\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Bit Depth",
+                    "name" : "Bit Depth",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                        "name" : "prp/9",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "rate",
+                      "description" : "Bits Per Sample"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"BitDepth\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Bit Depth",
+                    "name" : "Bit Depth",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                        "name" : "prp/9",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "rate",
+                      "description" : "Bits Per Sample"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:sampleSize",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Sampling Frequency",
+                    "name" : "Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b34f92b5-e549-5f3d-95a3-02ba0befc875",
+                        "name" : "prp/12",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "description" : "Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:samplingRate",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Creation Date",
+                    "name" : "Creation Date",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                        "name" : "prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "date",
+                      "description" : "Creation Date"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:dateCreated"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingApplication\"]"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Language",
+                    "name" : "Language",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "1e547c8a-7237-5da7-b4e8-60df45515f89",
+                        "name" : "prp/24",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Language"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioTrack/@trackLanguage",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Duration",
+                    "name" : "Duration",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bf17b78e-365d-52d0-881a-42a31e2f60eb",
+                        "name" : "prp/10002",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "size",
+                      "description" : "Length In Seconds"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:duration/ebucore:normalPlayTime/substring(., 3)"
+                  }, {
+                    "description" : "Number of Audio Channels",
+                    "name" : "Number of Audio Channels",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "df6dd369-a2b8-5fae-9a25-396dd040863a",
+                        "name" : "prp/10003",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Audio Channels"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:channels",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Bitrate Is Variable",
+                    "name" : "Bitrate Is Variable",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                        "name" : "prp/10004",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "boolean",
+                      "class" : "other",
+                      "description" : "Bitrate Is Variable"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Bitrate Is Variable",
+                    "name" : "Bitrate Is Variable",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                        "name" : "prp/10004",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "boolean",
+                      "class" : "other",
+                      "description" : "Bitrate Is Variable"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Audio Bitrate",
+                    "name" : "Audio Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRate",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Video Bitrate",
+                    "name" : "Video Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRate",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Overall Bitrate",
+                    "name" : "Overall Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                        "name" : "prp/10005",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"OverallBitRate\"]"
+                  }, {
+                    "description" : "Encoding Type",
+                    "name" : "Encoding Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                        "name" : "prp/10006",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Encoding Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:videoEncoding/@typeLabel",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Encoding Type",
+                    "name" : "Encoding Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                        "name" : "prp/10006",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Encoding Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioEncoding/@typeLabel",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Number Of Video Streams",
+                    "name" : "Number Of Video Streams",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                        "name" : "prp/10008",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Streams"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:videoFormat)"
+                  }, {
+                    "description" : "Number Of Audio Streams",
+                    "name" : "Number Of Audio Streams",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                        "name" : "prp/10008",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "other",
+                      "description" : "Number Of Streams"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:audioFormat)"
+                  }, {
+                    "description" : "Frame Rate",
+                    "name" : "Frame Rate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "8e7ccea1-b280-537e-8054-b790a0700b25",
+                        "name" : "prp/10009",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "description" : "Frames Per Second"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:frameRate",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Horizontal Aspect Ratio",
+                    "name" : "Horizontal Aspect Ratio",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                        "name" : "prp/10011",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aspect Ratio"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorNumerator",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Vertical Aspect Ratio",
+                    "name" : "Vertical Aspect Ratio",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                        "name" : "prp/10011",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aspect Ratio"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorDenominator",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Max Audio Bitrate",
+                    "name" : "Max Audio Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                        "name" : "prp/10012",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Max Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRateMax",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Max Video Bitrate",
+                    "name" : "Max Video Bitrate",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                        "name" : "prp/10012",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "rate",
+                      "units" : "kpbs",
+                      "description" : "Max Bitrate (kbps)"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRateMax",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Codec Name",
+                    "name" : "Codec Name",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                        "name" : "TSS-prp/10",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Commercial Codec Name"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/@videoFormatName",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Codec Name",
+                    "name" : "Codec Name",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                        "name" : "TSS-prp/10",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Commercial Codec Name"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/@audioFormatName",
+                    "groupLabel" : "Audio Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                  }, {
+                    "description" : "Format Profile",
+                    "name" : "Format Profile",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "96456871-2f91-508f-aeb1-1dfe5d468bba",
+                        "name" : "TSS-prp/11",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Format Profile"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"FormatProfile\"]"
+                  }, {
+                    "description" : "Chroma Sampling",
+                    "name" : "Chroma Sampling",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "5c49dab0-d830-5249-999e-41f5eeaba76e",
+                        "name" : "TSS-prp/39",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Chroma Sampling"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"FormatProfile\"]",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Scan Type",
+                    "name" : "Scan Type",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "4d94d78b-eade-508f-94e2-9a15c2b2d5de",
+                        "name" : "TSS-prp/40",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Scan Type"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:scanningFormat",
+                    "groupLabel" : "Video Stream",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                  }, {
+                    "description" : "Timecode Start",
+                    "name" : "Timecode Start",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "21f9b9f6-b380-5841-a4e0-b08b7cbd4cec",
+                        "name" : "TSS-prp/41",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Timecode"
+                    },
+                    "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:timecodeFormat/ebucore:timecodeStart/ebucore:timecode",
+                    "groupLabel" : "Timecode",
+                    "groupIdBinding" : "xpath:ancestor::ebucore:timecodeFormat/count(preceding-sibling::ebucore:timecodeFormat)"
+                  } ],
+                  "rawOutputs" : [ {
+                    "description" : "Raw EBUCore output from the tool",
+                    "name" : "EBUCore"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                      "name" : "mediainfo-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "mediainfo",
+                    "toolName" : "MediaInfo CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "MediaArea - https://mediaarea.net",
+                    "toolVersion" : "18.12-1"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  }
+                }, {
+                  "description" : "Migrate to Web Ready MP4 using FFMPEG",
+                  "example" : "ffmpeg -i ${inputfile} -movflags -ab 128k -acodec aac -vb 500k -vcodec libx264 -maxrate 500k -profile:v high -threads 0 -preset slow -bufsize 1000k -pix_fmt yuv420p ${outputfile}",
+                  "id" : {
+                    "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                    "name" : "migrate-to-web-ready-mp4-ffmpeg",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile.$ext"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Input file",
+                    "type" : "command_line",
+                    "value" : "-i"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  }, {
+                    "description" : "MOOV Metadata Position Specifier",
+                    "type" : "command_line",
+                    "value" : "-movflags"
+                  }, {
+                    "description" : "Move MOOV metadata to start",
+                    "type" : "command_line",
+                    "value" : "faststart"
+                  }, {
+                    "description" : "Audio Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-ab"
+                  }, {
+                    "description" : "Audio Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "128k"
+                  }, {
+                    "description" : "Audio Codec Specifier",
+                    "type" : "command_line",
+                    "value" : "-acodec"
+                  }, {
+                    "description" : "Audio Codec Value",
+                    "type" : "command_line",
+                    "value" : "aac"
+                  }, {
+                    "description" : "Video Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-vb"
+                  }, {
+                    "description" : "Video Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "500k"
+                  }, {
+                    "description" : "Video Codec Specifier",
+                    "type" : "command_line",
+                    "value" : "-vcodec"
+                  }, {
+                    "description" : "Video Codec Value",
+                    "type" : "command_line",
+                    "value" : "libx264"
+                  }, {
+                    "description" : "Maximum Bitrate Specifier",
+                    "type" : "command_line",
+                    "value" : "-maxrate"
+                  }, {
+                    "description" : "Maximum Bitrate Value",
+                    "type" : "command_line",
+                    "value" : "500k"
+                  }, {
+                    "description" : "Video Profile Specifier",
+                    "type" : "command_line",
+                    "value" : "-profile:v"
+                  }, {
+                    "description" : "Video Profile Value",
+                    "type" : "command_line",
+                    "value" : "high"
+                  }, {
+                    "description" : "Thread Control Specifier",
+                    "type" : "command_line",
+                    "value" : "-threads"
+                  }, {
+                    "description" : "Thread Control Value",
+                    "type" : "command_line",
+                    "value" : "0"
+                  }, {
+                    "description" : "Encoding Speed to Compression Rate Preset Specifier",
+                    "type" : "command_line",
+                    "value" : "-preset"
+                  }, {
+                    "description" : "Encoding Speed to Compression Rate Preset Value",
+                    "type" : "command_line",
+                    "value" : "slow"
+                  }, {
+                    "description" : "Buffer Size Specifier",
+                    "type" : "command_line",
+                    "value" : "-bufsize"
+                  }, {
+                    "description" : "Buffer Size Value",
+                    "type" : "command_line",
+                    "value" : "1000k"
+                  }, {
+                    "description" : "Pixel Format Specifier",
+                    "type" : "command_line",
+                    "value" : "-pix_fmt"
+                  }, {
+                    "description" : "Pixel Format Value",
+                    "type" : "command_line",
+                    "value" : "yuv420p"
+                  }, {
+                    "description" : "Output file name",
+                    "type" : "command_line",
+                    "value" : "${outputfile}"
+                  } ],
+                  "outputFiles" : [ {
+                    "description" : "File that will be created",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile.mp4"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "a2e3e12e-6b2a-551f-b0af-b3ba71e71754",
+                      "name" : "ffmpeg-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "ffmpeg",
+                    "toolName" : "FFMPEG CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "FFMPEG - https://www.ffmpeg.org/",
+                    "toolVersion" : "3.1.4"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                      "name" : "mig",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "migration"
+                  }
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/PreservationActions'
+      summary: Get Preservation Actions
+      tags:
+        - /preservation-actions
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Preservation Action and returns the action as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationAction'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Preservation Action
+      tags:
+        - /preservation-actions
+  /preservation-actions/{guid}:
+    delete:
+      consumes: []
+      description: >-
+        Deletes the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Preservation Action successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Preservation Action
+      tags:
+        - /preservation-actions
+    get:
+      consumes: []
+      description: >-
+        Returns the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '404':
+          description: >-
+            If the specified guid does not reference a Preservation Action known
+            to this registry.
+      summary: Get a Preservation Action
+      tags:
+        - /preservation-actions
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Preservation Action specified by the GUID of the PAR
+        Identifier and returns the action as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/PreservationAction'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                "example" : "exiftool -X ${inputFile}",
+                "id" : {
+                  "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                  "name" : "extract-camera-raw",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "inputFiles" : [ {
+                  "description" : "File that will be acted upon",
+                  "file" : {
+                    "filepath" : ""
+                  },
+                  "name" : "inputfile"
+                } ],
+                "inputToolArguments" : [ {
+                  "description" : "Generate output in XML format",
+                  "type" : "command_line",
+                  "value" : "-X"
+                }, {
+                  "description" : "Input file name",
+                  "type" : "command_line",
+                  "value" : "${inputfile}"
+                } ],
+                "outputProperties" : [ {
+                  "description" : "Image Width",
+                  "name" : "Image Width",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                      "name" : "prp/3",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Width"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                }, {
+                  "description" : "Image Height",
+                  "name" : "Image Height",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                      "name" : "prp/4",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "size",
+                    "units" : "pixels",
+                    "description" : "Image Height"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                }, {
+                  "description" : "Colour Space",
+                  "name" : "Colour Space",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                }, {
+                  "description" : "Sampling Frequency Unit",
+                  "name" : "Sampling Frequency Unit",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                      "name" : "prp/6",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Sampling Frequency Unit"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                }, {
+                  "description" : "X Sampling Frequency",
+                  "name" : "X Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                      "name" : "prp/7",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "X Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                }, {
+                  "description" : "Y Sampling Frequency",
+                  "name" : "Y Sampling Frequency",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                      "name" : "prp/8",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Y Sampling Frequency"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                }, {
+                  "description" : "Creation Date",
+                  "name" : "Creation Date",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                      "name" : "prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "date",
+                    "description" : "Creation Date"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                }, {
+                  "description" : "Creating Application",
+                  "name" : "Creating Application",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                      "name" : "prp/19",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Creating Application"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                }, {
+                  "description" : "Camera",
+                  "name" : "Camera",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                      "name" : "TSS-prp/14",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "provenance",
+                    "description" : "Camera"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                }, {
+                  "description" : "ISO Speed",
+                  "name" : "ISO Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                      "name" : "TSS-prp/15",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "ISO speed"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                }, {
+                  "description" : "Shutter Speed",
+                  "name" : "Shutter Speed",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                      "name" : "TSS-prp/16",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Shutter"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                }, {
+                  "description" : "Aperture",
+                  "name" : "Aperture",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                      "name" : "TSS-prp/17",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Aperture"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                }, {
+                  "description" : "Focal Length",
+                  "name" : "Focal Length",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                      "name" : "TSS-prp/18",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Focal Length"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                }, {
+                  "description" : "ExposureTime",
+                  "name" : "Exposure Time",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                      "name" : "TSS-prp/22",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "float",
+                    "class" : "other",
+                    "units" : "seconds",
+                    "description" : "Exposure Time"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                }, {
+                  "description" : "FNumber",
+                  "name" : "FNumber",
+                  "parProperty" : {
+                    "id" : {
+                      "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                      "name" : "TSS-prp/23",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "FNumber"
+                  },
+                  "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                } ],
+                "rawOutputs" : [ {
+                  "description" : "Raw RDF based XML output from the tool",
+                  "name" : "RDF-XML"
+                } ],
+                "tool" : {
+                  "id" : {
+                    "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                    "name" : "exiftool-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "exiftool",
+                  "toolName" : "ExifTool",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                  "toolVersion" : "10.80"
+                },
+                "type" : {
+                  "id" : {
+                    "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                    "name" : "mee",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "metadata extraction"
+                }
+              }
+          schema:
+            $ref: '#/definitions/PreservationAction'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Preservation Action
+      tags:
+        - /preservation-actions
+  /properties:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Properties that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Properties modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Properties. This filter matches
+            only those Properties that are identified by one of the listed
+            GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Properties. This filter matches
+            only those Properties that are identified by one of the listed
+            names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Properties whose local last modified
+            date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Properties whose local last modified
+            date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Property to return from the start of the list of all matching
+            Properties.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Properties to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "parProperties" : [ {
+                  "id" : {
+                    "guid" : "e21641c7-ea11-5f10-9a00-64a7b62d2b95",
+                    "name" : "prp/10",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "integer",
+                  "class" : "rate",
+                  "description" : "Samples Per Pixel"
+                }, {
+                  "id" : {
+                    "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                    "name" : "prp/5",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "string",
+                  "class" : "other",
+                  "description" : "Colour Space"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/ParProperties'
+      summary: Get Properties
+      tags:
+        - /properties
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Property and returns the property as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/ParProperty'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Property
+      tags:
+        - /properties
+  /properties/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Property specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Property successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Property
+      tags:
+        - /properties
+    get:
+      consumes: []
+      description: Returns the Property specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '404':
+          description: >-
+            If the specified guid does not reference a Property known to this
+            registry.
+      summary: Get a Property
+      tags:
+        - /properties
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Property specified by the GUID of the PAR Identifier and
+        returns the property as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/ParProperty'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                  "name" : "prp/1",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "type" : "string",
+                "class" : "algorithm",
+                "description" : "Compression Type"
+              }
+          schema:
+            $ref: '#/definitions/ParProperty'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Property
+      tags:
+        - /properties
+  /representation-formats:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Representation Formats that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+        
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any RepresentationFormats modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of file formats. This filter matches 
+            only those Business Rules that have been defined to apply to one of 
+            the listed formats. This includes formats where the rule is 
+            applicable indirectly through the format family.
+          in: header
+          name: file-format-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of file formats. This filter matches 
+            only those Business Rules that have been defined to apply to one of 
+            the listed formats. This includes formats where the rule is 
+            applicable indirectly through the format family.
+          in: header
+          name: file-format-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of formats families. This filter 
+            matches only those Business Rules that have been defined to apply to 
+            one of the listed format families. 
+          in: header
+          name: format-family-guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of formats families. This filter 
+            matches only those Business Rules that have been defined to apply to 
+            one of the listed format families. 
+          in: header
+          name: format-family-name
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of GUIDs of Representation Formats. This filter matches
+            only those Representation Formats that are identified by one of the listed
+            GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Representation Formats. This filter matches
+            only those Representation Formats that are identified by one of the listed
+            names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Representation Formats whose local last
+            modified date is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Representation Formats whose local last
+            modified date is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first RepresentationFormat to return from the start of the list of all
+            matching Representation Formats.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of RepresentationFormats to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "representationFormats" : [{
+                  "id": {
+                    "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                    "name": "repfmt/1",
+                    "namespace": "http://par.preservica.com"
+                  },
+                  "name": "Email",
+                  "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                  "representationFormatSignature": {
+                    "primaryFileCriteria": [
+                      {
+                        "formatFamilies": [
+                          {
+                            "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                            "name": "email",
+                            "namespace": "http://par.preservica.com"
+                          }
+                        ]
+                      }
+                    ],
+                    "fileCriteria": [
+                      {
+                        "minimum": "0",
+                        "maximum": "unbounded"
+                      }
+                    ]
+                  }
+                },{
+                  "id": {
+                    "guid": "b7ad4e34-304e-5b41-959f-9afb9fe5cd70",
+                    "name": "repfmt/2",
+                    "namespace": "http://par.preservica.com"
+                  },
+                  "name": "Tweet",
+                  "description": "A Tweet is described by a primary Tweet JSON file. This file may reference up to 4 jpg or png images and up to 1 MP4 video.",
+                  "representationFormatSignature": {
+                    "primaryFileCriteria": [
+                      {
+                        "formats": [
+                          {
+                            "guid": "61370fce-f770-5018-9d6d-39bd639c59cb",
+                            "name": "fmt/1311",
+                            "namespace": "http://www.nationalarchives.gov.uk"
+                          }
+                        ]
+                      }
+                    ],
+                    "fileCriteria": [
+                      {
+                        "formatFamilies": [
+                          {
+                            "guid": "7bcc3e4c-4e97-556e-9592-8d7ea62187fa",
+                            "name": "jpeg",
+                            "namespace": "http://par.preservica.com"
+                          },
+                          {
+                            "guid": "b7d2f299-ec03-591e-be30-16b74b599b3d",
+                            "name": "png",
+                            "namespace": "http://par.preservica.com"
+                          }
+                        ],
+                        "minimum": "0",
+                        "maximum": "4"
+                      },
+                      {
+                        "formats": [
+                          {
+                            "guid": "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                            "name": "fmt/199",
+                            "namespace": "http://www.nationalarchives.gov.uk"
+                          }
+                        ],
+                        "minimum": "0",
+                        "maximum": "1"
+                      }
+                    ]
+                  }
+                }]
+              }
+          schema:
+            $ref: '#/definitions/RepresentationFormats'
+      summary: Get Representation Formats
+      tags:
+        - /representation-formats
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Creates a new Representation Format and
+        returns the Representation Format as updated.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Representation Format
+      tags:
+        - /representation-formats
+  /representation-formats/{guid}:
+    delete:
+        consumes: []
+        description: Deletes the Representation Format specified by the GUID of the PAR Identifier
+        parameters:
+          - in: path
+            name: guid
+            required: true
+            type: string
+          - description: HTTP Basic Auth header
+            in: header
+            name: Authorization
+            required: true
+            type: string
+        produces: []
+        responses:
+          '204':
+            description: Representation Format successfully deleted.
+          '401':
+            description: If no Authorization header has been supplied.
+          '403':
+            description: >-
+              If the supplied Authorization header does not reference a user with
+              write access to this registry.
+        summary: Delete Representation Format
+        tags:
+          - /representation-formats
+    get:
+      consumes: []
+      description: Returns the Representation Format specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id": {
+                  "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                  "name": "repfmt/1",
+                  "namespace": "http://par.preservica.com"
+                },
+                "name": "Email",
+                "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                "representationFormatSignature": {
+                  "primaryFileCriteria": [
+                    {
+                      "formatFamilies": [
+                        {
+                          "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                          "name": "email",
+                          "namespace": "http://par.preservica.com"
+                        }
+                      ]
+                    }
+                  ],
+                  "fileCriteria": [
+                    {
+                      "minimum": "0",
+                      "maximum": "unbounded"
+                    }
+                  ]
+                }
+              }
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+        '404':
+          description: >-
+            If the specified guid does not reference a Representation Format known to this
+            registry.
+      summary: Get a Representation Format
+      tags:
+        - /representation-formats
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Representation Format specified by the GUID of the PAR Identifier and
+        returns the Representation Format as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              
+          schema:
+            $ref: '#/definitions/RepresentationFormat'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Representation Format
+      tags:
+        - /representation-formats
+  /tools:
+    get:
+      consumes: []
+      description: >-
+        Returns an array of Tools that match all of the filter conditions
+        supplied. Any number of filters can be used together.
+
+        The date filters should be supplied as ISO-8601 date times or dates,
+        i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+
+        If no time information is supplied, then 00:00:00 in UTC will be
+        assumed. This means that if you supply modified-after and
+        modified-before dates of 2019-01-01 and 2019-12-31, you will not match
+        any Tools modified during the day of 31st December.
+      parameters:
+        - description: >-
+            A comma separated list of GUIDs of Tools. This filter matches only
+            those Tools that are identified by one of the listed GUIDs.
+          in: header
+          name: guid
+          required: false
+          type: string
+        - description: >-
+            A comma separated list of names of Tools. This filter matches only
+            those Tools that are identified by one of the listed names.
+          in: header
+          name: name
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Tools whose local last modified date
+            is after the specified date.
+          in: query
+          name: modified-after
+          required: false
+          type: string
+        - description: >-
+            This filter matches only those Tools whose local last modified date
+            is before the specified date.
+          in: query
+          name: modified-before
+          required: false
+          type: string
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the offset of the
+            first Tool to return from the start of the list of all matching
+            Tools.
+          in: query
+          name: offset
+          required: false
+          type: integer
+        - default: 0
+          description: >-
+            Used for requesting paged responses, this defines the maximum number
+            of Tools to return.
+          in: query
+          name: limit
+          required: false
+          type: integer
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "tools" : [ {
+                  "id" : {
+                    "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                    "name" : "mediainfo-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "mediainfo",
+                  "toolName" : "MediaInfo CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "MediaArea - https://mediaarea.net",
+                  "toolVersion" : "18.12-1"
+                }, {
+                  "id" : {
+                    "guid" : "efa0ee01-6a6c-5e97-ad47-eb7c08e94ad0",
+                    "name" : "libreoffice-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "soffice",
+                  "toolName" : "LibreOffice CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "The Document Foundation - https://www.libreoffice.org/",
+                  "toolVersion" : "5.3.5.2"
+                } ]
+              }
+          schema:
+            $ref: '#/definitions/Tools'
+      summary: Get Tools
+      tags:
+        - /tools
+    post:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: Creates a new Tool and returns the tool as created.
+      parameters:
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Tool'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '401':
+          description: If no Authorization header has been supplied
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Create Tool
+      tags:
+        - /tools
+  /tools/{guid}:
+    delete:
+      consumes: []
+      description: Deletes the Tool specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+      produces: []
+      responses:
+        '204':
+          description: Tool successfully deleted.
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Delete Tool
+      tags:
+        - /tools
+    get:
+      consumes: []
+      description: Returns the Tool specified by the GUID of the PAR Identifier
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '200':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '404':
+          description: >-
+            If the specified guid does not reference a Tool known to this
+            registry.
+      summary: Get a Tool
+      tags:
+        - /tools
+    put:
+      consumes:
+        - application/json;charset=UTF-8 
+      description: >-
+        Updates the Tool specified by the GUID of the PAR Identifier and returns
+        the tool as updated.
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          type: string
+        - description: HTTP Basic Auth header
+          in: header
+          name: Authorization
+          required: true
+          type: string
+        - description: Serialised entity in request body
+          in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Tool'
+      produces:
+        - application/json;charset=UTF-8
+      responses:
+        '201':
+          description: Success
+          examples:
+            application/json;charset=UTF-8: |-
+              {
+                "id" : {
+                  "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                  "name" : "imagemagick-cli",
+                  "namespace" : "http://par.preservica.com"
+                },
+                "toolLabel" : "convert",
+                "toolName" : "ImageMagick CLI",
+                "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                "toolVersion" : "6.7.8-9"
+              }
+          schema:
+            $ref: '#/definitions/Tool'
+        '401':
+          description: If no Authorization header has been supplied.
+        '403':
+          description: >-
+            If the supplied Authorization header does not reference a user with
+            write access to this registry.
+      summary: Update Tool
+      tags:
+        - /tools
+schemes:
+  - https
+swagger: '2.0'
+tags:
+  - description: Requests relating to PAR Business Rule entities
+    name: /business-rules
+  - description: Endpoints relating to PAR Preservation Action entities
+    name: /preservation-actions
+  - description: Endpoints relating to PAR Tool entities
+    name: /tools
+  - description: Endpoints relating to PAR File Format entities.
+    name: /file-formats
+  - description: Endpoints relating to PAR Representation Format entities
+    name: /representation-formats
+  - description: Endpoints relating to PAR Property entities
+    name: /properties
+  - description: Endpoints relating to PAR Preservation Action Type Type entities
+    name: /preservation-action-types
+  - description: Endpoints relating to PAR Format Family entities
+    name: /format-families

--- a/docs/api/1.2/index.html
+++ b/docs/api/1.2/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>My New API</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "par-api.yaml", //Location of Open API spec in the repo
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/docs/api/1.2/par-api.yaml
+++ b/docs/api/1.2/par-api.yaml
@@ -1,0 +1,5311 @@
+openapi: 3.0.1
+info:
+  title: PAR API
+  description: API to retrieve and update Business Rules, Preservation Actions etc
+    from a Preservation Action Registries compliant endpoint
+  version: "1.2"
+servers:
+- url: https://parcore.org/par
+tags:
+- name: /business-rules
+  description: Requests relating to PAR Business Rule entities
+- name: /preservation-actions
+  description: Endpoints relating to PAR Preservation Action entities
+- name: /tools
+  description: Endpoints relating to PAR Tool entities
+- name: /file-formats
+  description: Endpoints relating to PAR File Format entities.
+- name: /representation-formats
+  description: Endpoints relating to PAR Representation Format entities
+- name: /properties
+  description: Endpoints relating to PAR Property entities
+- name: /preservation-action-types
+  description: Endpoints relating to PAR Preservation Action Type Type entities
+- name: /format-families
+  description: Endpoints relating to PAR Format Family entities
+paths:
+  /business-rules:
+    get:
+      tags:
+      - /business-rules
+      summary: Get Business Rules
+      description: |-
+        Returns an array of Business Rules that match all of the filter conditions supplied. Any number of fitlers can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Business Rules modified during the day of 31st December.
+      parameters:
+      - name: preservation-action-guid
+        in: header
+        description: A comma separated list of GUIDs of Preservation Actions. This
+          filter matches only those Business Rules whose purpose is to perform one
+          of the listed actions.
+        schema:
+          type: string
+      - name: preservation-action-name
+        in: header
+        description: A comma separated list of names of Preservation Actions. This
+          filter matches only those Business Rules whose purpose is to perform one
+          of the listed actions.
+        schema:
+          type: string
+      - name: preservation-action-type-guid
+        in: header
+        description: A comma separated list of GUIDs of Preservation Action Types.
+          This filter matches only those Business Rules whose purpose is to perform
+          one of the listed types of action.
+        schema:
+          type: string
+      - name: preservation-action-type-name
+        in: header
+        description: A comma separated list of name of Preservation Action Types.
+          This filter matches only those Business Rules whose purpose is to perform
+          one of the listed types of action.
+        schema:
+          type: string
+      - name: file-format-guid
+        in: header
+        description: A comma separated list of GUIDs of file formats. This filter
+          matches  only those Business Rules that have been defined to apply to one
+          of  the listed formats. This includes formats where the rule is  applicable
+          indirectly through the format family.
+        schema:
+          type: string
+      - name: file-format-name
+        in: header
+        description: A comma separated list of names of file formats. This filter
+          matches  only those Business Rules that have been defined to apply to one
+          of  the listed formats. This includes formats where the rule is  applicable
+          indirectly through the format family.
+        schema:
+          type: string
+      - name: format-family-guid
+        in: header
+        description: 'A comma separated list of names of formats families. This filter  matches
+          only those Business Rules that have been defined to apply to  one of the
+          listed format families. '
+        schema:
+          type: string
+      - name: format-family-name
+        in: header
+        description: 'A comma separated list of names of formats families. This filter  matches
+          only those Business Rules that have been defined to apply to  one of the
+          listed format families. '
+        schema:
+          type: string
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Business Rules. This filter
+          matches only those Business Rules that are identified by one of the listed
+          GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Business Rules. This filter
+          matches only those Business Rules that are identified by one of the listed
+          names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Business Rules whose local last
+          modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Business Rules whose local last
+          modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Business Rule to return from the start of the list of all matching
+          Business Rules.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Business Rules to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/BusinessRules'
+              example: |-
+                {
+                  "businessRules" : [ {
+                    "id" : {
+                      "guid" : "cb2bea88-8006-58fa-a395-dcf0d76a32ee",
+                      "name" : "mediainfo-extraction-of-video",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "description" : "For property extraction of Video file formats, use the MediaInfo CLI",
+                    "formats" : [ {
+                      "guid" : "6590d828-10ac-5aa4-aaf8-36f073343432",
+                      "name" : "fmt/735",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "e534e808-9680-5945-8046-5fface23cd93",
+                      "name" : "fmt/951",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "84dbb5f7-b722-5817-8762-e05c1ef17759",
+                      "name" : "fmt/973",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "993a1df3-7da3-5972-b765-431195b3f009",
+                      "name" : "fmt/1086",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "61a35b4f-34c0-51b4-9dd3-8f03c79b69a8",
+                      "name" : "x-fmt/139",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "9fdb2a8d-3143-54c1-a3ae-83f122b5fd4c",
+                      "name" : "x-fmt/419",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ],
+                    "formatFamilies" : [ {
+                      "id" : {
+                        "guid" : "60303765-0d86-5f48-a26c-96daec3b754b",
+                        "name" : "video",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "familyType" : "Video File Formats",
+                      "fileFormats" : [ {
+                        "guid" : "dfc92377-0582-584b-9bce-661cc365b10d",
+                        "name" : "TSS-fmt/4",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                        "name" : "fmt/649",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                        "name" : "fmt/506",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "f3252fc5-f9fe-5b4f-925e-edc4653a7ff0",
+                        "name" : "fmt/193",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                        "name" : "fmt/786",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                        "name" : "fmt/131",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                        "name" : "fmt/499",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                        "name" : "fmt/133",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                        "name" : "fmt/199",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                        "name" : "fmt/200",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "9947c06d-591e-56bd-98df-8c15a5d38655",
+                        "name" : "TSS-fmt/13",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "cc6f693f-3e92-5e6c-a5f4-dde355f9b498",
+                        "name" : "TSS-fmt/15",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "36ce7b02-d2cb-5d23-bad3-de475d3e8eea",
+                        "name" : "fmt/105",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                        "name" : "x-fmt/385",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "82c41aa8-bf6a-50ba-97b1-d28f3b25d77a",
+                        "name" : "fmt/107",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "eba99ac5-b80b-560f-9d0f-cb371260246d",
+                        "name" : "TSS-fmt/11",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                        "name" : "fmt/109",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "ec00c475-d655-57f0-b2df-aefe8c0c943e",
+                        "name" : "TSS-fmt/9",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                        "name" : "fmt/507",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                        "name" : "fmt/505",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                        "name" : "fmt/945",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                        "name" : "fmt/569",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "80a02837-3b02-5e43-beb8-b8121343da71",
+                        "name" : "fmt/1055",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                        "name" : "fmt/731",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "83e012dd-d83c-577f-982f-07d2e846e93d",
+                        "name" : "fmt/110",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "98bdd321-0f14-5ff8-b174-5470977c4fb4",
+                        "name" : "TSS-fmt/3",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                        "name" : "fmt/5",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                        "name" : "fmt/585",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "e104d7fb-0d2c-55d7-ba89-65cdd41b5be7",
+                        "name" : "fmt/640",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                        "name" : "fmt/573",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "b4471a17-e68e-5979-9299-7e9f78772d89",
+                        "name" : "TSS-fmt/14",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                        "name" : "x-fmt/386",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "2253f81a-8692-5ddd-8010-99c2a2461360",
+                        "name" : "fmt/104",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "2d398b99-4a15-5fb9-93ad-c6dfa86b8d78",
+                        "name" : "TSS-fmt/16",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                        "name" : "fmt/425",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "f92ffa76-ef89-55df-89ef-94bca58e4e2d",
+                        "name" : "TSS-fmt/10",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "3aa32617-a451-5fe2-856f-b5e0e0b5b968",
+                        "name" : "fmt/106",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                        "name" : "fmt/108",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "dd86844e-3988-55ac-bc19-43bfe86be1ba",
+                        "name" : "TSS-fmt/12",
+                        "namespace" : "http://tessella.com"
+                      }, {
+                        "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                        "name" : "x-fmt/152",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                        "name" : "x-fmt/384",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                        "name" : "x-fmt/190",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                        "name" : "x-fmt/382",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      } ]
+                    }, {
+                      "id" : {
+                        "guid" : "ae7ebffb-5140-53a6-9a9a-adbe90953f45",
+                        "name" : "asf",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "familyType" : "Format Group",
+                      "fileFormats" : [ {
+                        "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                        "name" : "fmt/131",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "dfc81f25-27a1-51f0-a437-5a9be605205b",
+                        "name" : "fmt/505",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "3a911ebe-77f0-5f8f-bd2d-967c0b04dfbc",
+                        "name" : "fmt/506",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "3ab0c6bd-1772-5224-9e8d-329c5e56deb5",
+                        "name" : "fmt/507",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "dbd65709-a393-5d73-9b68-0355972532ba",
+                        "name" : "x-fmt/137",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      } ]
+                    }, {
+                      "id" : {
+                        "guid" : "7c62e0ea-4846-52d4-b62b-ab99d7084d7d",
+                        "name" : "wma",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "familyType" : "Format Group",
+                      "fileFormats" : [ {
+                        "guid" : "eb916390-88b6-5431-b8e3-cf03e44c7554",
+                        "name" : "fmt/132",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      } ]
+                    }, {
+                      "id" : {
+                        "guid" : "c6c99061-2702-5b83-98fe-e6f46d1c007b",
+                        "name" : "mpeg-audio",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "familyType" : "Format Group",
+                      "fileFormats" : [ {
+                        "guid" : "6efff7b7-3ddb-57ab-85bb-3501ba202afe",
+                        "name" : "fmt/134",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "76a512ae-6c0b-5e11-bf2f-714ffa770ea2",
+                        "name" : "fmt/198",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "984e8161-82c7-5821-9b08-2ed9580b0fd5",
+                        "name" : "fmt/347",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "3a7d7cb5-f8f7-5414-b155-f6558cf9e897",
+                        "name" : "x-fmt/279",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      } ]
+                    }, {
+                      "id" : {
+                        "guid" : "ae87efa4-cd5a-5d07-b1b7-251a4fe871c8",
+                        "name" : "ogg",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "familyType" : "Format Group",
+                      "fileFormats" : [ {
+                        "guid" : "9ba33cd0-6339-5add-9c10-cd9a430a1d84",
+                        "name" : "fmt/203",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                        "name" : "fmt/945",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "98adc483-d0cd-58b4-84d8-0d4117b53089",
+                        "name" : "fmt/946",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "d67128ec-b34b-525a-a228-0c5cf692b22c",
+                        "name" : "fmt/947",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      }, {
+                        "guid" : "d04d2361-05d5-582f-a83c-c573f6e34cc1",
+                        "name" : "fmt/948",
+                        "namespace" : "http://www.nationalarchives.gov.uk"
+                      } ]
+                    } ],
+                    "preservationActionTypes" : [ {
+                      "id" : {
+                        "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                        "name" : "mee",
+                        "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                      },
+                      "label" : "metadata extraction"
+                    } ],
+                    "preservationActions" : [ {
+                      "preservationAction" : {
+                        "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                        "name" : "video-extract-mediainfo",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "priority" : 1
+                    } ],
+                    "notes" : "Use MediaInfo for Property Extraction"
+                  }, {
+                    "id" : {
+                      "guid" : "9396cbc6-03d2-5195-ac8e-05017913defc",
+                      "name" : "property-extraction-of-camera-raw",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "description" : "For Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW Images use ExifTool",
+                    "formats" : [ {
+                      "guid" : "026d9445-7056-5824-adf8-0ab7db541319",
+                      "name" : "fmt/202",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "1fff9428-6bf2-5a90-8afd-c560a63d2f33",
+                      "name" : "fmt/642",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "29814d1c-020e-5156-9405-3562137b4295",
+                      "name" : "fmt/668",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "4b8cac87-b6ba-57d4-8f4e-02f35ba32c64",
+                      "name" : "fmt/669",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ],
+                    "preservationActionTypes" : [ {
+                      "id" : {
+                        "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                        "name" : "mee",
+                        "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                      },
+                      "label" : "metadata extraction"
+                    } ],
+                    "preservationActions" : [ {
+                      "preservationAction" : {
+                        "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                        "name" : "extract-camera-raw",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "priority" : 1
+                    } ],
+                    "notes" : "Use ExifTool for Nikon, Fujifilm, Olympus and Minolta RAW Image Property Extraction"
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /business-rules
+      summary: Create Business Rule
+      description: Creates a new Business Rule and returns the rule as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/BusinessRule'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/BusinessRule'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                    "name" : "web-ready-mp4-migration-ffmpeg",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                  "formats" : [ {
+                    "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                    "name" : "fmt/5",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                    "name" : "fmt/108",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                    "name" : "fmt/109",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                    "name" : "fmt/131",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                    "name" : "fmt/133",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                    "name" : "fmt/199",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                    "name" : "fmt/200",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                    "name" : "fmt/425",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                    "name" : "fmt/499",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                    "name" : "fmt/573",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                    "name" : "fmt/585",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                    "name" : "fmt/649",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                    "name" : "fmt/731",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                    "name" : "fmt/786",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                    "name" : "fmt/935",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                    "name" : "fmt/945",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                    "name" : "x-fmt/152",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                    "name" : "x-fmt/190",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                    "name" : "x-fmt/382",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                    "name" : "x-fmt/384",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                    "name" : "x-fmt/385",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                    "name" : "x-fmt/386",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                      "name" : "mig",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "migration"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                      "name" : "ffmpeg-web-ready-migration",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /business-rules/{guid}:
+    get:
+      tags:
+      - /business-rules
+      summary: Get a Business Rule
+      description: Returns the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/BusinessRule'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                    "name" : "web-ready-mp4-migration-ffmpeg",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                  "formats" : [ {
+                    "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                    "name" : "fmt/5",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                    "name" : "fmt/108",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                    "name" : "fmt/109",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                    "name" : "fmt/131",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                    "name" : "fmt/133",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                    "name" : "fmt/199",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                    "name" : "fmt/200",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                    "name" : "fmt/425",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                    "name" : "fmt/499",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                    "name" : "fmt/573",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                    "name" : "fmt/585",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                    "name" : "fmt/649",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                    "name" : "fmt/731",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                    "name" : "fmt/786",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                    "name" : "fmt/935",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                    "name" : "fmt/945",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                    "name" : "x-fmt/152",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                    "name" : "x-fmt/190",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                    "name" : "x-fmt/382",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                    "name" : "x-fmt/384",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                    "name" : "x-fmt/385",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                    "name" : "x-fmt/386",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                      "name" : "mig",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "migration"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                      "name" : "ffmpeg-web-ready-migration",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+                }
+        404:
+          description: If the specified guid does not reference a Business Rule known
+            to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /business-rules
+      summary: Update Business Rule
+      description: Updates the Business Rule specified by the GUID of the PAR Identifier
+        and returns the rule as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/BusinessRule'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/BusinessRule'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "85fb1396-7625-55ed-b25c-6f6e75e6b27a",
+                    "name" : "web-ready-mp4-migration-ffmpeg",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "description" : "Migrate video to web-presentable MP4 using FFmpeg",
+                  "formats" : [ {
+                    "guid" : "f21bab26-c3ab-57d0-b1d6-fcdf1d451842",
+                    "name" : "fmt/5",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8b38c945-081e-5135-bfea-276e2127ce3a",
+                    "name" : "fmt/108",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "7e3419fd-2410-54e2-ad71-0982b81acd38",
+                    "name" : "fmt/109",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f8fb693b-e2d6-51c8-91b5-ef79fcdcb3bb",
+                    "name" : "fmt/131",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a6935eb3-54c7-56f8-acf0-87563d803142",
+                    "name" : "fmt/133",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                    "name" : "fmt/199",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "614228d4-c022-5679-b74b-6f127d5c4ce8",
+                    "name" : "fmt/200",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "a3e220e6-2241-51dc-a00b-cd4e9a11efe7",
+                    "name" : "fmt/425",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "35bbdd65-3556-5080-aeeb-fe466514a05a",
+                    "name" : "fmt/499",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bd2f2266-05bc-52c8-80c1-63d7efa1886a",
+                    "name" : "fmt/573",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "19b8b2eb-64a5-5e0e-9726-5da7552e9ac2",
+                    "name" : "fmt/585",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "27a4b10f-9090-556b-9078-50e1c5c83a71",
+                    "name" : "fmt/649",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "8bda423a-b6f2-55dc-bd4c-034952d2070a",
+                    "name" : "fmt/731",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4a7b6f86-6b6d-50e6-8773-7ea371fe9ce4",
+                    "name" : "fmt/786",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "dc9f3053-a788-5904-9711-3059338bca04",
+                    "name" : "fmt/935",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4b5ee9ea-1528-58dd-b7a5-80099c11a2e7",
+                    "name" : "fmt/945",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "4341c3b3-d26d-56a7-a2db-5f75fd8aa0a9",
+                    "name" : "x-fmt/152",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "6899a72e-f4d0-5768-a197-40fe3dabffe9",
+                    "name" : "x-fmt/190",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "b4450c2f-30d2-55a5-bad8-78c5ba0d1d26",
+                    "name" : "x-fmt/382",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "0aa8edb4-3078-574a-97fe-34922d2c2ca1",
+                    "name" : "x-fmt/384",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "f45f2474-f7fb-55a0-a8d6-1f171c4109aa",
+                    "name" : "x-fmt/385",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                    "name" : "x-fmt/386",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                      "name" : "mig",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "migration"
+                  } ],
+                  "preservationActions" : [ {
+                    "preservationAction" : {
+                      "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                      "name" : "ffmpeg-web-ready-migration",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "priority" : 1
+                  } ],
+                  "notes" : "Use FFmpeg for migration of video files to web presentable MP4 using FFmpeg, this uses the AAC audio and H.264 video codecs."
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /business-rules
+      summary: Delete Business Rule
+      description: Deletes the Business Rule specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Business Rule successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /file-formats:
+    get:
+      tags:
+      - /file-formats
+      summary: Get File Formats
+      description: |-
+        Returns an array of File Formats that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any FileFormats modified during the day of 31st December.
+      parameters:
+      - name: guid
+        in: header
+        description: A comma separated list of the GUIDs of File Formats. This filter
+          matches only those File Formats that are identified by one of the listed
+          GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of the names of File Formats. This filter
+          matches only those File Formats that are identified by one of the listed
+          names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those File Formats whose local last
+          modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those File Formats whose local last
+          modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first FileFormat to return from the start of the list of all matching
+          File Formats.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of FileFormats to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FileFormats'
+              example: |-
+                {
+                  "fileFormats" : [ {
+                    "description" : "This is an outline record only, and requires further details, research or authentication to provide information that will enable users to further understand the format and to assess digital preservation risks associated with it if appropriate.",
+                    "externalSignatures" : [ {
+                      "signature" : "f4a",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "m4v",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "m4a",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "f4v",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "mp4",
+                      "signatureType" : "File Extension"
+                    } ],
+                    "id" : {
+                      "guid" : "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                      "name" : "fmt/199",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    },
+                    "internalSignatures" : [ {
+                      "byteSequences" : [ {
+                        "byteSequenceId" : "bs/357",
+                        "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                        "byteSequenceValue" : "66747970{0-64}(6D703432|6D703431|69736F6D|69736F32)*6D6F6F76",
+                        "encoding" : "PRONOM",
+                        "maxOffset" : "0",
+                        "offset" : "4",
+                        "positionType" : "Absolute from BOF"
+                      } ],
+                      "signatureId" : "is/278",
+                      "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                    } ],
+                    "localLastModifiedDate" : "2017-07-05T20:22:48Z",
+                    "name" : "MPEG-4 Media File",
+                    "relatedFormats" : [ {
+                      "relatedFormatId" : "x-fmt/384",
+                      "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "relatedFormatName" : "Quicktime",
+                      "relatedFormatVersion" : "\n      ",
+                      "relationshipType" : "Has priority over"
+                    }, {
+                      "relatedFormatId" : "fmt/596",
+                      "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "relatedFormatName" : "Apple Lossless Audio Codec",
+                      "relatedFormatVersion" : "\n      ",
+                      "relationshipType" : "Has lower priority than"
+                    }, {
+                      "relatedFormatId" : "fmt/357",
+                      "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "relatedFormatName" : "3GPP Audio/Video File",
+                      "relatedFormatVersion" : "\n      ",
+                      "relationshipType" : "Has lower priority than"
+                    } ],
+                    "types" : [ "Video" ],
+                    "version" : "\n      "
+                  }, {
+                    "description" : "MPEG-2 is a lossy compression standard (an improvement and expansion of the MPEG-1 standard) designed for the generic coding of video and audio and intended to cover a wide scope of application, including: video production, broadcast and editing. Streams are at potentially higher bitrates than MPEG-1 but more efficient compression making it suited to High Definition video. MPEG-2 Video supports both 'progressive' and 'interlaced' frame video. An MPG-2 ‘Program’ stream (PS) file (*.mpg, *.mpeg) generally contain both video and audio streams, generally for synchronised playback, and may carry a variety of other data (e.g. video captions).\n\nSome camcorders store their MPEG-2 Program Stream video data as files with the .mod extension, usually alongside other files containing metadata and management information for the video.",
+                    "externalSignatures" : [ {
+                      "signature" : "mod",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "mpeg",
+                      "signatureType" : "File Extension"
+                    }, {
+                      "signature" : "mpg",
+                      "signatureType" : "File Extension"
+                    } ],
+                    "id" : {
+                      "guid" : "9f7df46e-89d4-57b7-ad22-26e6a9748422",
+                      "name" : "x-fmt/386",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    },
+                    "identifiers" : [ {
+                      "identifier" : "x-fmt/386",
+                      "identifierType" : "PUID"
+                    }, {
+                      "identifier" : "video/mpeg",
+                      "identifierType" : "MIME"
+                    } ],
+                    "internalSignatures" : [ {
+                      "byteSequences" : [ {
+                        "byteSequenceId" : "bs/800",
+                        "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                        "byteSequenceValue" : "000001BA{8-12}000001BB{8-65536}000001B3{8-136}000001B5",
+                        "encoding" : "PRONOM",
+                        "maxOffset" : "0",
+                        "offset" : "0",
+                        "positionType" : "Absolute from BOF"
+                      } ],
+                      "signatureId" : "is/655",
+                      "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                    } ],
+                    "localLastModifiedDate" : "2019-07-30T19:28:46Z",
+                    "name" : "MPEG-2 Program Stream",
+                    "relatedFormats" : [ {
+                      "relatedFormatId" : "x-fmt/385",
+                      "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "relatedFormatName" : "MPEG-1 Program Stream",
+                      "relatedFormatVersion" : "\n      ",
+                      "relationshipType" : "Has priority over"
+                    }, {
+                      "relatedFormatId" : "fmt/425",
+                      "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "relatedFormatName" : "Video Object File (MPEG-2 subset)",
+                      "relatedFormatVersion" : "\n      ",
+                      "relationshipType" : "Has lower priority than"
+                    } ],
+                    "types" : [ "Video" ],
+                    "version" : "\n      "
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /file-formats
+      summary: Create File Format
+      description: Creates a new File Format and returns the fileFormat as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/FileFormat'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FileFormat'
+              example: |-
+                {
+                  "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                  "externalSignatures" : [ {
+                    "signature" : "wbk",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "doc",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                    "name" : "fmt/40",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "identifiers" : [ {
+                    "identifier" : "fmt/40",
+                    "identifierType" : "PUID"
+                  }, {
+                    "identifier" : "application/msword",
+                    "identifierType" : "MIME"
+                  } ],
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/223",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    }, {
+                      "byteSequenceId" : "bs/222",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Absolute from BOF"
+                    }, {
+                      "byteSequenceId" : "bs/224",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    } ],
+                    "signatureId" : "is/182",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                  "name" : "Microsoft Word Document",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "fmt/39",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document",
+                    "relatedFormatVersion" : "6.0/95",
+                    "relationshipType" : "Is subsequent version of"
+                  }, {
+                    "relatedFormatId" : "fmt/609",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word (Generic)",
+                    "relatedFormatVersion" : "6.0-2003",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/111",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "OLE2 Compound Document Format",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "x-fmt/45",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/755",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/754",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Document" ],
+                  "version" : "97-2003"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /file-formats/{guid}:
+    get:
+      tags:
+      - /file-formats
+      summary: Get a File Format
+      description: Returns the File Format specified by the Name part of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FileFormat'
+              example: |-
+                {
+                  "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                  "externalSignatures" : [ {
+                    "signature" : "wbk",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "doc",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                    "name" : "fmt/40",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "identifiers" : [ {
+                    "identifier" : "fmt/40",
+                    "identifierType" : "PUID"
+                  }, {
+                    "identifier" : "application/msword",
+                    "identifierType" : "MIME"
+                  } ],
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/223",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    }, {
+                      "byteSequenceId" : "bs/222",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Absolute from BOF"
+                    }, {
+                      "byteSequenceId" : "bs/224",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    } ],
+                    "signatureId" : "is/182",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                  "name" : "Microsoft Word Document",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "fmt/39",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document",
+                    "relatedFormatVersion" : "6.0/95",
+                    "relationshipType" : "Is subsequent version of"
+                  }, {
+                    "relatedFormatId" : "fmt/609",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word (Generic)",
+                    "relatedFormatVersion" : "6.0-2003",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/111",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "OLE2 Compound Document Format",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "x-fmt/45",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/755",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/754",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Document" ],
+                  "version" : "97-2003"
+                }
+        404:
+          description: If the specified name does not reference a File Format known
+            to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /file-formats
+      summary: Update File Format
+      description: Updates the File Format specified by the Name part of the PAR Identifier
+        and returns the file format as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/FileFormat'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FileFormat'
+              example: |-
+                {
+                  "description" : "With the release of Word 97, Microsoft revised the native binary word processing format, which is based on its generic OLE2 Compound Document Format. The format is proprietary and Microsoft does not make details of its structure public. The information here is derived primarily from OpenOffice.org's reverse-engineered documentation of the format and should not therefore be regarded as definitive. A Word document is stored as a ‘WordDocument’ stream within a Compound Document Format file. The format remained unchanged with the releases of Word 2000, 2002 and 2003. An alternative extension of .wbk refers to a backup file of a Word document, however there is no material or structural difference between a .wbk file and the .doc file it is a backup of.",
+                  "externalSignatures" : [ {
+                    "signature" : "wbk",
+                    "signatureType" : "File Extension"
+                  }, {
+                    "signature" : "doc",
+                    "signatureType" : "File Extension"
+                  } ],
+                  "id" : {
+                    "guid" : "fd71f444-9a3b-533b-89a0-aec2404db911",
+                    "name" : "fmt/40",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  },
+                  "identifiers" : [ {
+                    "identifier" : "fmt/40",
+                    "identifierType" : "PUID"
+                  }, {
+                    "identifier" : "application/msword",
+                    "identifierType" : "MIME"
+                  } ],
+                  "internalSignatures" : [ {
+                    "byteSequences" : [ {
+                      "byteSequenceId" : "bs/223",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "57006F007200640044006F00630075006D0065006E007400{42}02(00|01)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    }, {
+                      "byteSequenceId" : "bs/222",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "D0CF11E0A1B11AE1{20}FEFF",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Absolute from BOF"
+                    }, {
+                      "byteSequenceId" : "bs/224",
+                      "byteSequenceIdNamespace" : "http://www.nationalarchives.gov.uk",
+                      "byteSequenceValue" : "4D6963726F736F667420576F7264(20382E30|20392E30|2031302E30|2D446F6B756D656E74)",
+                      "encoding" : "PRONOM",
+                      "maxOffset" : "0",
+                      "offset" : "0",
+                      "positionType" : "Variable"
+                    } ],
+                    "signatureId" : "is/182",
+                    "signatureIdNamespace" : "http://www.nationalarchives.gov.uk"
+                  } ],
+                  "localLastModifiedDate" : "2017-07-05T20:22:59Z",
+                  "name" : "Microsoft Word Document",
+                  "relatedFormats" : [ {
+                    "relatedFormatId" : "fmt/39",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document",
+                    "relatedFormatVersion" : "6.0/95",
+                    "relationshipType" : "Is subsequent version of"
+                  }, {
+                    "relatedFormatId" : "fmt/609",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word (Generic)",
+                    "relatedFormatVersion" : "6.0-2003",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "fmt/111",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "OLE2 Compound Document Format",
+                    "relatedFormatVersion" : "\n      ",
+                    "relationshipType" : "Has priority over"
+                  }, {
+                    "relatedFormatId" : "x-fmt/45",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/755",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document Template (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  }, {
+                    "relatedFormatId" : "fmt/754",
+                    "relatedFormatIdNamespace" : "http://www.nationalarchives.gov.uk",
+                    "relatedFormatName" : "Microsoft Word Document (Password Protected)",
+                    "relatedFormatVersion" : "97-2003",
+                    "relationshipType" : "Has lower priority than"
+                  } ],
+                  "types" : [ "Document" ],
+                  "version" : "97-2003"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /file-formats
+      summary: Delete File Format
+      description: Deletes the File Format specified by the Name part of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: File Format successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /format-families:
+    get:
+      tags:
+      - /format-families
+      summary: Get Format Families
+      description: |-
+        Returns an array of Format Families that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Format Families modified during the day of 31st December.
+      parameters:
+      - name: file-format-guid
+        in: header
+        description: A comma separated list of guids of file formats (i.e. fmt/1,
+          x-fmt/2. This filter matches only those Format Families that include any
+          of the specified formats.
+        schema:
+          type: string
+      - name: file-format-name
+        in: header
+        description: A comma separated list of names of file formats. This filter
+          matches only those Format Families that include any of the specified formats.
+        schema:
+          type: string
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Format Families. This filter
+          matches only those Format Families that are identified by one of the listed
+          GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Format Families. This filter
+          matches only those Format Families that are identified by one of the listed
+          names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Format Families whose local last
+          modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Format Families whose local last
+          modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Format Family to return from the start of the list of all matching
+          Format Families.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Format Families to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FormatFamilies'
+              example: |-
+                {
+                  "formatFamilies" : [ {
+                    "id" : {
+                      "guid" : "d7df91be-c3d1-51f2-8432-2d9ac63c43e7",
+                      "name" : "matroska",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Format Group",
+                    "fileFormats" : [ {
+                      "guid" : "4ea966c9-a431-56d1-9c34-5a56c1c4d32b",
+                      "name" : "fmt/569",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  }, {
+                    "id" : {
+                      "guid" : "402dbdaf-92c9-5d4f-adb0-aeb787a692b3",
+                      "name" : "container",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "familyType" : "Content Type",
+                    "fileFormats" : [ {
+                      "guid" : "ac5ed58c-9059-57d4-ad58-a7206d5fbf12",
+                      "name" : "fmt/1071",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "da90e482-2c08-57b9-ac63-6ef3c2837ca8",
+                      "name" : "fmt/1087",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "fbf38e85-1980-5bb9-be01-1a15d99eb817",
+                      "name" : "fmt/289",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "ce998789-ec87-527e-a76d-9c6767fd4adb",
+                      "name" : "fmt/410",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "0897d6a7-a4c7-5869-8ed0-add85047fcd0",
+                      "name" : "fmt/411",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "d67def5c-a7a8-522a-a193-b76d8c3c77b3",
+                      "name" : "fmt/468",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "607c448a-3778-5445-b70f-ddce7d6e84a9",
+                      "name" : "fmt/484",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "c3494448-8509-5728-ac7c-f1e8d6150729",
+                      "name" : "fmt/625",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "9748cefb-43f7-5d88-aef5-eb5f6e52cf36",
+                      "name" : "TSS-fmt/2",
+                      "namespace" : "http://tessella.com"
+                    }, {
+                      "guid" : "76d0b902-f0c6-5960-b581-be2a3c9d825f",
+                      "name" : "x-fmt/219",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "c2955350-56f8-5198-9193-777f0c022168",
+                      "name" : "x-fmt/263",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "7fe92564-d680-5656-9239-2b54ce2664e1",
+                      "name" : "x-fmt/264",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "de799ae7-7ae5-5efd-88b9-ac36532a8bde",
+                      "name" : "x-fmt/265",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "3d063d8a-4a5a-584c-858f-e476436153bf",
+                      "name" : "x-fmt/266",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "010115c8-2844-54d8-a61b-88b89b8694a4",
+                      "name" : "x-fmt/267",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "c0b77a9d-919b-5657-9e98-186fc81d2348",
+                      "name" : "x-fmt/268",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    }, {
+                      "guid" : "76d983f6-1aef-5cc2-941c-32778c3dd241",
+                      "name" : "x-fmt/412",
+                      "namespace" : "http://www.nationalarchives.gov.uk"
+                    } ]
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /format-families
+      summary: Create Format Family
+      description: Creates a new Format Family and returns the family as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/FormatFamily'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FormatFamily'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                    "name" : "ooxmltypes",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Open Office XML Formats",
+                  "fileFormats" : [ {
+                    "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                    "name" : "fmt/214",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                    "name" : "fmt/412",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                    "name" : "fmt/215",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                    "name" : "fmt/599",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                    "name" : "fmt/629",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /format-families/{guid}:
+    get:
+      tags:
+      - /format-families
+      summary: Get a Format Family
+      description: Returns the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FormatFamily'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                    "name" : "ooxmltypes",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Open Office XML Formats",
+                  "fileFormats" : [ {
+                    "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                    "name" : "fmt/214",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                    "name" : "fmt/412",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                    "name" : "fmt/215",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                    "name" : "fmt/599",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                    "name" : "fmt/629",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                }
+        404:
+          description: If the specified guid does not reference a Format Family known
+            to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /format-families
+      summary: Update Format Family
+      description: Updates the Format Family specified by the GUID of the PAR Identifier
+        and returns the family as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/FormatFamily'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/FormatFamily'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "92a903da-be38-5c0c-97f4-c6aff4c98abf",
+                    "name" : "ooxmltypes",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "familyType" : "Open Office XML Formats",
+                  "fileFormats" : [ {
+                    "guid" : "0d0e98d7-f5a4-5002-b3ea-e21c0fa2f06a",
+                    "name" : "fmt/214",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "30a7b22d-d71a-5bf7-b43a-490579e1d347",
+                    "name" : "fmt/412",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "bf17f1cd-ecca-5e56-9a8a-7b20da94fa45",
+                    "name" : "fmt/215",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "3b519ec6-c528-54d4-9702-67e09c76cebe",
+                    "name" : "fmt/599",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  }, {
+                    "guid" : "d026a4dd-ddc2-57e1-9503-2c5d62095827",
+                    "name" : "fmt/629",
+                    "namespace" : "http://www.nationalarchives.gov.uk"
+                  } ]
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /format-families
+      summary: Delete Format Family
+      description: Deletes the Format Family specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Format Family successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /preservation-action-types:
+    get:
+      tags:
+      - /preservation-action-types
+      summary: Get Preservation Action Types
+      description: |-
+        Returns an array of Preservation Action Types that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Preservation Action Types modified during the day of 31st December.
+      parameters:
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Preservation Action Types.
+          This filter matches only those Preservation Action Types that are identified
+          by one of the listed GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Preservation Action Types.
+          This filter matches only those Preservation Action Types that are identified
+          by one of the listed names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Preservation Action Types whose
+          local last modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Preservation Action Types whose
+          local last modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Preservation Action Type to return from the start of the list
+          of all matching Preservation Action Types.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Preservation Action Types to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationActionTypes'
+              example: |-
+                {
+                  "preservationActionTypes" : [ {
+                    "id" : {
+                      "guid" : "5f0fbe10-deec-5965-abbb-2474a857a39f",
+                      "name" : "fix",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "fixity check"
+                  }, {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /preservation-action-types
+      summary: Create Preservation Action Type
+      description: Creates a new Preservation Action Type and returns the type as
+        created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/PreservationActionType'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationActionType'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /preservation-action-types/{guid}:
+    get:
+      tags:
+      - /preservation-action-types
+      summary: Get a Preservation Action Type
+      description: Returns the Preservation Action Type specified by the GUID of the
+        PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationActionType'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                }
+        404:
+          description: If the specified guid does not reference a Preservation Action
+            Type known to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /preservation-action-types
+      summary: Update Preservation Action Type
+      description: Updates the Preservation Action Type specified by the GUID of the
+        PAR Identifier and returns the type as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/PreservationActionType'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationActionType'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                    "name" : "mig",
+                    "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                  },
+                  "label" : "migration"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /preservation-action-types
+      summary: Delete Preservation Action Type
+      description: Deletes the Preservation Action Type specified by the GUID of the
+        PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Preservation Action Type successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /preservation-actions:
+    get:
+      tags:
+      - /preservation-actions
+      summary: Get Preservation Actions
+      description: |-
+        Returns an array of Preservation Actions that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Preservation Actions modified during the day of 31st December.
+      parameters:
+      - name: preservation-action-type-guid
+        in: header
+        description: A comma separated list of GUIDs of Preservation Action Types.
+          This filter matches only those Preservation Actions of one of the listed
+          types of action.
+        schema:
+          type: string
+      - name: preservation-action-type-name
+        in: header
+        description: A comma separated list of names of Preservation Action Types.
+          This filter matches only those Preservation Actions of one of the listed
+          types of action.
+        schema:
+          type: string
+      - name: tool-guid
+        in: header
+        description: A comma separated list of GUIDs of Tools. This filter matches
+          only those Preservation Actions that use one of the listed tools.
+        schema:
+          type: string
+      - name: tool-name
+        in: header
+        description: A comma separated list of names of Tools. This filter matches
+          only those Preservation Actions that use one of the listed tools.
+        schema:
+          type: string
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Preservation Actions. This
+          filter matches only those Preservation Actions that are identified by one
+          of the listed GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Preservation Actions. This
+          filter matches only those Preservation Actions that are identified by one
+          of the listed names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Preservation Actions whose local
+          last modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Preservation Actions whose local
+          last modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Preservation Action to return from the start of the list of
+          all matching Preservation Actions.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Preservation Actions to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationActions'
+              example: |-
+                {
+                  "preservationActions" : [ {
+                    "description" : "Property Extraction of video files using MediaInfo CLI and EBUCore Metadata",
+                    "example" : "mediainfo --Output=EBUCore ${inputfile}",
+                    "id" : {
+                      "guid" : "bed3a85b-cd2c-55d7-939b-cfe063479cfa",
+                      "name" : "video-extract-mediainfo",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "inputFiles" : [ {
+                      "description" : "File that will be acted upon",
+                      "file" : {
+                        "filepath" : ""
+                      },
+                      "name" : "inputfile"
+                    } ],
+                    "inputToolArguments" : [ {
+                      "description" : "Generate output in EBUCore XML format",
+                      "type" : "command_line",
+                      "value" : "--Output=EBUCore"
+                    }, {
+                      "description" : "Input file name",
+                      "type" : "command_line",
+                      "value" : "${inputfile}"
+                    } ],
+                    "outputProperties" : [ {
+                      "description" : "Video Width",
+                      "name" : "Video Width",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                          "name" : "prp/3",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "size",
+                        "units" : "pixels",
+                        "description" : "Image Width"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:width",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Video Height",
+                      "name" : "Video Height",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                          "name" : "prp/4",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "size",
+                        "units" : "pixels",
+                        "description" : "Image Height"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:height",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Colour Space",
+                      "name" : "Colour Space",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                          "name" : "prp/5",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Colour Space"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"ColorSpace\"]",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Bit Depth",
+                      "name" : "Bit Depth",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                          "name" : "prp/9",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "rate",
+                        "description" : "Bits Per Sample"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"BitDepth\"]",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Bit Depth",
+                      "name" : "Bit Depth",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b228cf0f-55be-53e4-a84d-74de40e6a0fc",
+                          "name" : "prp/9",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "rate",
+                        "description" : "Bits Per Sample"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:sampleSize",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Sampling Frequency",
+                      "name" : "Sampling Frequency",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b34f92b5-e549-5f3d-95a3-02ba0befc875",
+                          "name" : "prp/12",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "description" : "Sampling Frequency"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:samplingRate",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Creation Date",
+                      "name" : "Creation Date",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                          "name" : "prp/14",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "date",
+                        "description" : "Creation Date"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:dateCreated"
+                    }, {
+                      "description" : "Creating Application",
+                      "name" : "Creating Application",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                          "name" : "prp/19",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "provenance",
+                        "description" : "Creating Application"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingApplication\"]"
+                    }, {
+                      "description" : "Creating Application",
+                      "name" : "Creating Application",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                          "name" : "prp/19",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "provenance",
+                        "description" : "Creating Application"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Creating Application",
+                      "name" : "Creating Application",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                          "name" : "prp/19",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "provenance",
+                        "description" : "Creating Application"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:technicalAttributeString[@typeLabel=\"WritingLibrary\"]",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Language",
+                      "name" : "Language",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "1e547c8a-7237-5da7-b4e8-60df45515f89",
+                          "name" : "prp/24",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Language"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioTrack/@trackLanguage",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Duration",
+                      "name" : "Duration",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "bf17b78e-365d-52d0-881a-42a31e2f60eb",
+                          "name" : "prp/10002",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "size",
+                        "description" : "Length In Seconds"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:duration/ebucore:normalPlayTime/substring(., 3)"
+                    }, {
+                      "description" : "Number of Audio Channels",
+                      "name" : "Number of Audio Channels",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "df6dd369-a2b8-5fae-9a25-396dd040863a",
+                          "name" : "prp/10003",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "other",
+                        "description" : "Number Of Audio Channels"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:channels",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Bitrate Is Variable",
+                      "name" : "Bitrate Is Variable",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                          "name" : "prp/10004",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "boolean",
+                        "class" : "other",
+                        "description" : "Bitrate Is Variable"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Bitrate Is Variable",
+                      "name" : "Bitrate Is Variable",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "bad29949-0b20-5022-9743-9b300923c5c4",
+                          "name" : "prp/10004",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "boolean",
+                        "class" : "other",
+                        "description" : "Bitrate Is Variable"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/exists(ebucore:bitRateMode[.=\"variable\"])",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Audio Bitrate",
+                      "name" : "Audio Bitrate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                          "name" : "prp/10005",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "units" : "kpbs",
+                        "description" : "Bitrate (kbps)"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRate",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Video Bitrate",
+                      "name" : "Video Bitrate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                          "name" : "prp/10005",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "units" : "kpbs",
+                        "description" : "Bitrate (kbps)"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRate",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Overall Bitrate",
+                      "name" : "Overall Bitrate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "c635c80b-2940-5dc2-a69c-7192c565b07e",
+                          "name" : "prp/10005",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "units" : "kpbs",
+                        "description" : "Bitrate (kbps)"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"OverallBitRate\"]"
+                    }, {
+                      "description" : "Encoding Type",
+                      "name" : "Encoding Type",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                          "name" : "prp/10006",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Encoding Type"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:videoEncoding/@typeLabel",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Encoding Type",
+                      "name" : "Encoding Type",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "a25fe9f4-2ff6-507b-bea6-d97082bafe17",
+                          "name" : "prp/10006",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Encoding Type"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:audioEncoding/@typeLabel",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Number Of Video Streams",
+                      "name" : "Number Of Video Streams",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                          "name" : "prp/10008",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "other",
+                        "description" : "Number Of Streams"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:videoFormat)"
+                    }, {
+                      "description" : "Number Of Audio Streams",
+                      "name" : "Number Of Audio Streams",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "f37517b1-c265-5da4-9947-ea9b57a544e8",
+                          "name" : "prp/10008",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "integer",
+                        "class" : "other",
+                        "description" : "Number Of Streams"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/count(ebucore:audioFormat)"
+                    }, {
+                      "description" : "Frame Rate",
+                      "name" : "Frame Rate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "8e7ccea1-b280-537e-8054-b790a0700b25",
+                          "name" : "prp/10009",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "description" : "Frames Per Second"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:frameRate",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Horizontal Aspect Ratio",
+                      "name" : "Horizontal Aspect Ratio",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                          "name" : "prp/10011",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Aspect Ratio"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorNumerator",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Vertical Aspect Ratio",
+                      "name" : "Vertical Aspect Ratio",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "68a01516-5210-5ac3-bf63-987b187ef975",
+                          "name" : "prp/10011",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Aspect Ratio"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:aspectRatio/ebucore:factorDenominator",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Max Audio Bitrate",
+                      "name" : "Max Audio Bitrate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                          "name" : "prp/10012",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "units" : "kpbs",
+                        "description" : "Max Bitrate (kbps)"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/ebucore:bitRateMax",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Max Video Bitrate",
+                      "name" : "Max Video Bitrate",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "7f261bc8-9134-5d81-8e84-f72330b46531",
+                          "name" : "prp/10012",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "float",
+                        "class" : "rate",
+                        "units" : "kpbs",
+                        "description" : "Max Bitrate (kbps)"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:bitRateMax",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Codec Name",
+                      "name" : "Codec Name",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                          "name" : "TSS-prp/10",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Commercial Codec Name"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/@videoFormatName",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Codec Name",
+                      "name" : "Codec Name",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "97749e9d-9dda-5df0-bb0a-ce7534aac635",
+                          "name" : "TSS-prp/10",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Commercial Codec Name"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:audioFormat/@audioFormatName",
+                      "groupLabel" : "Audio Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:audioFormat/count(preceding-sibling::ebucore:audioFormat)"
+                    }, {
+                      "description" : "Format Profile",
+                      "name" : "Format Profile",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "96456871-2f91-508f-aeb1-1dfe5d468bba",
+                          "name" : "TSS-prp/11",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Format Profile"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:containerFormat/ebucore:technicalAttributeInteger[@typeLabel=\"FormatProfile\"]"
+                    }, {
+                      "description" : "Chroma Sampling",
+                      "name" : "Chroma Sampling",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "5c49dab0-d830-5249-999e-41f5eeaba76e",
+                          "name" : "TSS-prp/39",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Chroma Sampling"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:technicalAttributeString[@typeLabel=\"FormatProfile\"]",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Scan Type",
+                      "name" : "Scan Type",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "4d94d78b-eade-508f-94e2-9a15c2b2d5de",
+                          "name" : "TSS-prp/40",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Scan Type"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:videoFormat/ebucore:scanningFormat",
+                      "groupLabel" : "Video Stream",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:videoFormat/count(preceding-sibling::ebucore:videoFormat)"
+                    }, {
+                      "description" : "Timecode Start",
+                      "name" : "Timecode Start",
+                      "parProperty" : {
+                        "id" : {
+                          "guid" : "21f9b9f6-b380-5841-a4e0-b08b7cbd4cec",
+                          "name" : "TSS-prp/41",
+                          "namespace" : "http://par.preservica.com"
+                        },
+                        "type" : "string",
+                        "class" : "other",
+                        "description" : "Timecode"
+                      },
+                      "toolBinding" : "xpath:/ebucore:ebuCoreMain/ebucore:coreMetadata/ebucore:format/ebucore:timecodeFormat/ebucore:timecodeStart/ebucore:timecode",
+                      "groupLabel" : "Timecode",
+                      "groupIdBinding" : "xpath:ancestor::ebucore:timecodeFormat/count(preceding-sibling::ebucore:timecodeFormat)"
+                    } ],
+                    "rawOutputs" : [ {
+                      "description" : "Raw EBUCore output from the tool",
+                      "name" : "EBUCore"
+                    } ],
+                    "tool" : {
+                      "id" : {
+                        "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                        "name" : "mediainfo-cli",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "toolLabel" : "mediainfo",
+                      "toolName" : "MediaInfo CLI",
+                      "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                      "toolPublisher" : "MediaArea - https://mediaarea.net",
+                      "toolVersion" : "18.12-1"
+                    },
+                    "type" : {
+                      "id" : {
+                        "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                        "name" : "mee",
+                        "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                      },
+                      "label" : "metadata extraction"
+                    }
+                  }, {
+                    "description" : "Migrate to Web Ready MP4 using FFMPEG",
+                    "example" : "ffmpeg -i ${inputfile} -movflags -ab 128k -acodec aac -vb 500k -vcodec libx264 -maxrate 500k -profile:v high -threads 0 -preset slow -bufsize 1000k -pix_fmt yuv420p ${outputfile}",
+                    "id" : {
+                      "guid" : "0078de49-50eb-5551-be98-378fa300fdc8",
+                      "name" : "migrate-to-web-ready-mp4-ffmpeg",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "inputFiles" : [ {
+                      "description" : "File that will be acted upon",
+                      "file" : {
+                        "filepath" : ""
+                      },
+                      "name" : "inputfile.$ext"
+                    } ],
+                    "inputToolArguments" : [ {
+                      "description" : "Input file",
+                      "type" : "command_line",
+                      "value" : "-i"
+                    }, {
+                      "description" : "Input file name",
+                      "type" : "command_line",
+                      "value" : "${inputfile}"
+                    }, {
+                      "description" : "MOOV Metadata Position Specifier",
+                      "type" : "command_line",
+                      "value" : "-movflags"
+                    }, {
+                      "description" : "Move MOOV metadata to start",
+                      "type" : "command_line",
+                      "value" : "faststart"
+                    }, {
+                      "description" : "Audio Bitrate Specifier",
+                      "type" : "command_line",
+                      "value" : "-ab"
+                    }, {
+                      "description" : "Audio Bitrate Value",
+                      "type" : "command_line",
+                      "value" : "128k"
+                    }, {
+                      "description" : "Audio Codec Specifier",
+                      "type" : "command_line",
+                      "value" : "-acodec"
+                    }, {
+                      "description" : "Audio Codec Value",
+                      "type" : "command_line",
+                      "value" : "aac"
+                    }, {
+                      "description" : "Video Bitrate Specifier",
+                      "type" : "command_line",
+                      "value" : "-vb"
+                    }, {
+                      "description" : "Video Bitrate Value",
+                      "type" : "command_line",
+                      "value" : "500k"
+                    }, {
+                      "description" : "Video Codec Specifier",
+                      "type" : "command_line",
+                      "value" : "-vcodec"
+                    }, {
+                      "description" : "Video Codec Value",
+                      "type" : "command_line",
+                      "value" : "libx264"
+                    }, {
+                      "description" : "Maximum Bitrate Specifier",
+                      "type" : "command_line",
+                      "value" : "-maxrate"
+                    }, {
+                      "description" : "Maximum Bitrate Value",
+                      "type" : "command_line",
+                      "value" : "500k"
+                    }, {
+                      "description" : "Video Profile Specifier",
+                      "type" : "command_line",
+                      "value" : "-profile:v"
+                    }, {
+                      "description" : "Video Profile Value",
+                      "type" : "command_line",
+                      "value" : "high"
+                    }, {
+                      "description" : "Thread Control Specifier",
+                      "type" : "command_line",
+                      "value" : "-threads"
+                    }, {
+                      "description" : "Thread Control Value",
+                      "type" : "command_line",
+                      "value" : "0"
+                    }, {
+                      "description" : "Encoding Speed to Compression Rate Preset Specifier",
+                      "type" : "command_line",
+                      "value" : "-preset"
+                    }, {
+                      "description" : "Encoding Speed to Compression Rate Preset Value",
+                      "type" : "command_line",
+                      "value" : "slow"
+                    }, {
+                      "description" : "Buffer Size Specifier",
+                      "type" : "command_line",
+                      "value" : "-bufsize"
+                    }, {
+                      "description" : "Buffer Size Value",
+                      "type" : "command_line",
+                      "value" : "1000k"
+                    }, {
+                      "description" : "Pixel Format Specifier",
+                      "type" : "command_line",
+                      "value" : "-pix_fmt"
+                    }, {
+                      "description" : "Pixel Format Value",
+                      "type" : "command_line",
+                      "value" : "yuv420p"
+                    }, {
+                      "description" : "Output file name",
+                      "type" : "command_line",
+                      "value" : "${outputfile}"
+                    } ],
+                    "outputFiles" : [ {
+                      "description" : "File that will be created",
+                      "file" : {
+                        "filepath" : ""
+                      },
+                      "name" : "inputfile.mp4"
+                    } ],
+                    "tool" : {
+                      "id" : {
+                        "guid" : "a2e3e12e-6b2a-551f-b0af-b3ba71e71754",
+                        "name" : "ffmpeg-cli",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "toolLabel" : "ffmpeg",
+                      "toolName" : "FFMPEG CLI",
+                      "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                      "toolPublisher" : "FFMPEG - https://www.ffmpeg.org/",
+                      "toolVersion" : "3.1.4"
+                    },
+                    "type" : {
+                      "id" : {
+                        "guid" : "45bad06c-e2c0-5b46-b740-0cd2ed140a6f",
+                        "name" : "mig",
+                        "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                      },
+                      "label" : "migration"
+                    }
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /preservation-actions
+      summary: Create Preservation Action
+      description: Creates a new Preservation Action and returns the action as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/PreservationAction'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationAction'
+              example: |-
+                {
+                  "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                  "example" : "exiftool -X ${inputFile}",
+                  "id" : {
+                    "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                    "name" : "extract-camera-raw",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Generate output in XML format",
+                    "type" : "command_line",
+                    "value" : "-X"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  } ],
+                  "outputProperties" : [ {
+                    "description" : "Image Width",
+                    "name" : "Image Width",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                        "name" : "prp/3",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Width"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                  }, {
+                    "description" : "Image Height",
+                    "name" : "Image Height",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                        "name" : "prp/4",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Height"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                  }, {
+                    "description" : "Colour Space",
+                    "name" : "Colour Space",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                        "name" : "prp/5",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Colour Space"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                  }, {
+                    "description" : "Sampling Frequency Unit",
+                    "name" : "Sampling Frequency Unit",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                        "name" : "prp/6",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Sampling Frequency Unit"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                  }, {
+                    "description" : "X Sampling Frequency",
+                    "name" : "X Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                        "name" : "prp/7",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "X Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                  }, {
+                    "description" : "Y Sampling Frequency",
+                    "name" : "Y Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                        "name" : "prp/8",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Y Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                  }, {
+                    "description" : "Creation Date",
+                    "name" : "Creation Date",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                        "name" : "prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "date",
+                      "description" : "Creation Date"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                  }, {
+                    "description" : "Camera",
+                    "name" : "Camera",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                        "name" : "TSS-prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Camera"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                  }, {
+                    "description" : "ISO Speed",
+                    "name" : "ISO Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                        "name" : "TSS-prp/15",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "ISO speed"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                  }, {
+                    "description" : "Shutter Speed",
+                    "name" : "Shutter Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                        "name" : "TSS-prp/16",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Shutter"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                  }, {
+                    "description" : "Aperture",
+                    "name" : "Aperture",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                        "name" : "TSS-prp/17",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aperture"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                  }, {
+                    "description" : "Focal Length",
+                    "name" : "Focal Length",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                        "name" : "TSS-prp/18",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Focal Length"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                  }, {
+                    "description" : "ExposureTime",
+                    "name" : "Exposure Time",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                        "name" : "TSS-prp/22",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "other",
+                      "units" : "seconds",
+                      "description" : "Exposure Time"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                  }, {
+                    "description" : "FNumber",
+                    "name" : "FNumber",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                        "name" : "TSS-prp/23",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "FNumber"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                  } ],
+                  "rawOutputs" : [ {
+                    "description" : "Raw RDF based XML output from the tool",
+                    "name" : "RDF-XML"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                      "name" : "exiftool-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "exiftool",
+                    "toolName" : "ExifTool",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                    "toolVersion" : "10.80"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  }
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /preservation-actions/{guid}:
+    get:
+      tags:
+      - /preservation-actions
+      summary: Get a Preservation Action
+      description: Returns the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationAction'
+              example: |-
+                {
+                  "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                  "example" : "exiftool -X ${inputFile}",
+                  "id" : {
+                    "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                    "name" : "extract-camera-raw",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Generate output in XML format",
+                    "type" : "command_line",
+                    "value" : "-X"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  } ],
+                  "outputProperties" : [ {
+                    "description" : "Image Width",
+                    "name" : "Image Width",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                        "name" : "prp/3",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Width"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                  }, {
+                    "description" : "Image Height",
+                    "name" : "Image Height",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                        "name" : "prp/4",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Height"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                  }, {
+                    "description" : "Colour Space",
+                    "name" : "Colour Space",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                        "name" : "prp/5",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Colour Space"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                  }, {
+                    "description" : "Sampling Frequency Unit",
+                    "name" : "Sampling Frequency Unit",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                        "name" : "prp/6",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Sampling Frequency Unit"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                  }, {
+                    "description" : "X Sampling Frequency",
+                    "name" : "X Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                        "name" : "prp/7",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "X Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                  }, {
+                    "description" : "Y Sampling Frequency",
+                    "name" : "Y Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                        "name" : "prp/8",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Y Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                  }, {
+                    "description" : "Creation Date",
+                    "name" : "Creation Date",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                        "name" : "prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "date",
+                      "description" : "Creation Date"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                  }, {
+                    "description" : "Camera",
+                    "name" : "Camera",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                        "name" : "TSS-prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Camera"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                  }, {
+                    "description" : "ISO Speed",
+                    "name" : "ISO Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                        "name" : "TSS-prp/15",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "ISO speed"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                  }, {
+                    "description" : "Shutter Speed",
+                    "name" : "Shutter Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                        "name" : "TSS-prp/16",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Shutter"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                  }, {
+                    "description" : "Aperture",
+                    "name" : "Aperture",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                        "name" : "TSS-prp/17",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aperture"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                  }, {
+                    "description" : "Focal Length",
+                    "name" : "Focal Length",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                        "name" : "TSS-prp/18",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Focal Length"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                  }, {
+                    "description" : "ExposureTime",
+                    "name" : "Exposure Time",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                        "name" : "TSS-prp/22",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "other",
+                      "units" : "seconds",
+                      "description" : "Exposure Time"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                  }, {
+                    "description" : "FNumber",
+                    "name" : "FNumber",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                        "name" : "TSS-prp/23",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "FNumber"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                  } ],
+                  "rawOutputs" : [ {
+                    "description" : "Raw RDF based XML output from the tool",
+                    "name" : "RDF-XML"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                      "name" : "exiftool-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "exiftool",
+                    "toolName" : "ExifTool",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                    "toolVersion" : "10.80"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  }
+                }
+        404:
+          description: If the specified guid does not reference a Preservation Action
+            known to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /preservation-actions
+      summary: Update Preservation Action
+      description: Updates the Preservation Action specified by the GUID of the PAR
+        Identifier and returns the action as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/PreservationAction'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PreservationAction'
+              example: |-
+                {
+                  "description" : "Property Extraction of Nikon, Fujifilm, Olympus and Minolta RAW image files using ExifTool",
+                  "example" : "exiftool -X ${inputFile}",
+                  "id" : {
+                    "guid" : "272bd75c-a356-5ce2-a143-96b923dc2bd7",
+                    "name" : "extract-camera-raw",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "inputFiles" : [ {
+                    "description" : "File that will be acted upon",
+                    "file" : {
+                      "filepath" : ""
+                    },
+                    "name" : "inputfile"
+                  } ],
+                  "inputToolArguments" : [ {
+                    "description" : "Generate output in XML format",
+                    "type" : "command_line",
+                    "value" : "-X"
+                  }, {
+                    "description" : "Input file name",
+                    "type" : "command_line",
+                    "value" : "${inputfile}"
+                  } ],
+                  "outputProperties" : [ {
+                    "description" : "Image Width",
+                    "name" : "Image Width",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "32dc069b-2dbf-513d-b70e-d23c3072b6ba",
+                        "name" : "prp/3",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Width"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageWidth"
+                  }, {
+                    "description" : "Image Height",
+                    "name" : "Image Height",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "6204a9ce-7f50-5367-b851-71e52f069141",
+                        "name" : "prp/4",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "integer",
+                      "class" : "size",
+                      "units" : "pixels",
+                      "description" : "Image Height"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ImageHeight"
+                  }, {
+                    "description" : "Colour Space",
+                    "name" : "Colour Space",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                        "name" : "prp/5",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Colour Space"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ColorSpace"
+                  }, {
+                    "description" : "Sampling Frequency Unit",
+                    "name" : "Sampling Frequency Unit",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d955e9ab-d3d4-5419-b64f-a5114cedba93",
+                        "name" : "prp/6",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Sampling Frequency Unit"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}ResolutionUnit"
+                  }, {
+                    "description" : "X Sampling Frequency",
+                    "name" : "X Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "239c5834-dc31-51b2-92f0-24c3fe74b821",
+                        "name" : "prp/7",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "X Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}XResolution"
+                  }, {
+                    "description" : "Y Sampling Frequency",
+                    "name" : "Y Sampling Frequency",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "5840d1f1-9128-594f-9418-73e4b9bbf2e8",
+                        "name" : "prp/8",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Y Sampling Frequency"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}YResolution"
+                  }, {
+                    "description" : "Creation Date",
+                    "name" : "Creation Date",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "39b45886-d054-5d33-8ba4-1f2ea8f0799a",
+                        "name" : "prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "date",
+                      "description" : "Creation Date"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/replace(Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}CreateDate, '([0-9]{4}):([0-9]{2}):([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}).*', '$1-$2-$3T$4.000Z')"
+                  }, {
+                    "description" : "Creating Application",
+                    "name" : "Creating Application",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "b26db185-b741-5134-a9eb-551de1994a5c",
+                        "name" : "prp/19",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Creating Application"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Software"
+                  }, {
+                    "description" : "Camera",
+                    "name" : "Camera",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f677b198-cf23-54b2-becb-eaf67d7f27fc",
+                        "name" : "TSS-prp/14",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "provenance",
+                      "description" : "Camera"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/concat(Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Make, \" \", Q{http://ns.exiftool.ca/EXIF/IFD0/1.0/}Model)"
+                  }, {
+                    "description" : "ISO Speed",
+                    "name" : "ISO Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "ced74d9b-66bd-5675-9098-97d4c3af5034",
+                        "name" : "TSS-prp/15",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "ISO speed"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ISO"
+                  }, {
+                    "description" : "Shutter Speed",
+                    "name" : "Shutter Speed",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "883787f9-2746-52f1-8cff-3ce323d09881",
+                        "name" : "TSS-prp/16",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Shutter"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:ShutterSpeed"
+                  }, {
+                    "description" : "Aperture",
+                    "name" : "Aperture",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "d56485f2-1355-5b00-bb9e-ad4b870cb39f",
+                        "name" : "TSS-prp/17",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Aperture"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Composite:Aperture"
+                  }, {
+                    "description" : "Focal Length",
+                    "name" : "Focal Length",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "f7946816-ec74-5b32-9d9b-5f927f01aca5",
+                        "name" : "TSS-prp/18",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "Focal Length"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FocalLength"
+                  }, {
+                    "description" : "ExposureTime",
+                    "name" : "Exposure Time",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "15d81464-4ab6-58df-a0c2-b307de5955dd",
+                        "name" : "TSS-prp/22",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "float",
+                      "class" : "other",
+                      "units" : "seconds",
+                      "description" : "Exposure Time"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}ExposureTime"
+                  }, {
+                    "description" : "FNumber",
+                    "name" : "FNumber",
+                    "parProperty" : {
+                      "id" : {
+                        "guid" : "2266057b-2d9f-509b-bed6-47af349ca143",
+                        "name" : "TSS-prp/23",
+                        "namespace" : "http://par.preservica.com"
+                      },
+                      "type" : "string",
+                      "class" : "other",
+                      "description" : "FNumber"
+                    },
+                    "toolBinding" : "xpath:/rdf:RDF/rdf:Description/Q{http://ns.exiftool.ca/EXIF/ExifIFD/1.0/}FNumber"
+                  } ],
+                  "rawOutputs" : [ {
+                    "description" : "Raw RDF based XML output from the tool",
+                    "name" : "RDF-XML"
+                  } ],
+                  "tool" : {
+                    "id" : {
+                      "guid" : "222f87af-c8fd-584f-bccd-28b1b0a7b381",
+                      "name" : "exiftool-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "exiftool",
+                    "toolName" : "ExifTool",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "Phil Harvey - https://www.sno.phy.queensu.ca/~phil/exiftool/",
+                    "toolVersion" : "10.80"
+                  },
+                  "type" : {
+                    "id" : {
+                      "guid" : "3c2a1229-2aa0-5c0f-bf6b-b270386e4ce9",
+                      "name" : "mee",
+                      "namespace" : "http://id.loc.gov/vocabulary/preservation/eventType/"
+                    },
+                    "label" : "metadata extraction"
+                  }
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /preservation-actions
+      summary: Delete Preservation Action
+      description: Deletes the Preservation Action specified by the GUID of the PAR
+        Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Preservation Action successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /properties:
+    get:
+      tags:
+      - /properties
+      summary: Get Properties
+      description: |-
+        Returns an array of Properties that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Properties modified during the day of 31st December.
+      parameters:
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Properties. This filter matches
+          only those Properties that are identified by one of the listed GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Properties. This filter matches
+          only those Properties that are identified by one of the listed names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Properties whose local last modified
+          date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Properties whose local last modified
+          date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Property to return from the start of the list of all matching
+          Properties.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Properties to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ParProperties'
+              example: |-
+                {
+                  "parProperties" : [ {
+                    "id" : {
+                      "guid" : "e21641c7-ea11-5f10-9a00-64a7b62d2b95",
+                      "name" : "prp/10",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "integer",
+                    "class" : "rate",
+                    "description" : "Samples Per Pixel"
+                  }, {
+                    "id" : {
+                      "guid" : "dac8e896-851a-5aa1-91f9-c36f3d82dd21",
+                      "name" : "prp/5",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "type" : "string",
+                    "class" : "other",
+                    "description" : "Colour Space"
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /properties
+      summary: Create Property
+      description: Creates a new Property and returns the property as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/ParProperty'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ParProperty'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                    "name" : "prp/1",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "string",
+                  "class" : "algorithm",
+                  "description" : "Compression Type"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /properties/{guid}:
+    get:
+      tags:
+      - /properties
+      summary: Get a Property
+      description: Returns the Property specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ParProperty'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                    "name" : "prp/1",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "string",
+                  "class" : "algorithm",
+                  "description" : "Compression Type"
+                }
+        404:
+          description: If the specified guid does not reference a Property known to
+            this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /properties
+      summary: Update Property
+      description: Updates the Property specified by the GUID of the PAR Identifier
+        and returns the property as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/ParProperty'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ParProperty'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "00bfe91a-eb9d-540c-8b00-0497701d773a",
+                    "name" : "prp/1",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "type" : "string",
+                  "class" : "algorithm",
+                  "description" : "Compression Type"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /properties
+      summary: Delete Property
+      description: Deletes the Property specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Property successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          description: If the supplied Authorization header does not reference a user
+            with write access to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /representation-formats:
+    get:
+      tags:
+      - /representation-formats
+      summary: Get Representation Formats
+      description: |-
+        Returns an array of Representation Formats that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any RepresentationFormats modified during the day of 31st December.
+      parameters:
+      - name: file-format-guid
+        in: header
+        description: A comma separated list of GUIDs of file formats. This filter
+          matches  only those Business Rules that have been defined to apply to one
+          of  the listed formats. This includes formats where the rule is  applicable
+          indirectly through the format family.
+        schema:
+          type: string
+      - name: file-format-name
+        in: header
+        description: A comma separated list of names of file formats. This filter
+          matches  only those Business Rules that have been defined to apply to one
+          of  the listed formats. This includes formats where the rule is  applicable
+          indirectly through the format family.
+        schema:
+          type: string
+      - name: format-family-guid
+        in: header
+        description: 'A comma separated list of names of formats families. This filter  matches
+          only those Business Rules that have been defined to apply to  one of the
+          listed format families. '
+        schema:
+          type: string
+      - name: format-family-name
+        in: header
+        description: 'A comma separated list of names of formats families. This filter  matches
+          only those Business Rules that have been defined to apply to  one of the
+          listed format families. '
+        schema:
+          type: string
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Representation Formats. This
+          filter matches only those Representation Formats that are identified by
+          one of the listed GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Representation Formats. This
+          filter matches only those Representation Formats that are identified by
+          one of the listed names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Representation Formats whose local
+          last modified date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Representation Formats whose local
+          last modified date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first RepresentationFormat to return from the start of the list of
+          all matching Representation Formats.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of RepresentationFormats to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/RepresentationFormats'
+              example: |-
+                {
+                  "representationFormats" : [{
+                    "id": {
+                      "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                      "name": "repfmt/1",
+                      "namespace": "http://par.preservica.com"
+                    },
+                    "name": "Email",
+                    "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                    "representationFormatSignature": {
+                      "primaryFileCriteria": [
+                        {
+                          "formatFamilies": [
+                            {
+                              "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                              "name": "email",
+                              "namespace": "http://par.preservica.com"
+                            }
+                          ]
+                        }
+                      ],
+                      "fileCriteria": [
+                        {
+                          "minimum": "0",
+                          "maximum": "unbounded"
+                        }
+                      ]
+                    }
+                  },{
+                    "id": {
+                      "guid": "b7ad4e34-304e-5b41-959f-9afb9fe5cd70",
+                      "name": "repfmt/2",
+                      "namespace": "http://par.preservica.com"
+                    },
+                    "name": "Tweet",
+                    "description": "A Tweet is described by a primary Tweet JSON file. This file may reference up to 4 jpg or png images and up to 1 MP4 video.",
+                    "representationFormatSignature": {
+                      "primaryFileCriteria": [
+                        {
+                          "formats": [
+                            {
+                              "guid": "61370fce-f770-5018-9d6d-39bd639c59cb",
+                              "name": "fmt/1311",
+                              "namespace": "http://www.nationalarchives.gov.uk"
+                            }
+                          ]
+                        }
+                      ],
+                      "fileCriteria": [
+                        {
+                          "formatFamilies": [
+                            {
+                              "guid": "7bcc3e4c-4e97-556e-9592-8d7ea62187fa",
+                              "name": "jpeg",
+                              "namespace": "http://par.preservica.com"
+                            },
+                            {
+                              "guid": "b7d2f299-ec03-591e-be30-16b74b599b3d",
+                              "name": "png",
+                              "namespace": "http://par.preservica.com"
+                            }
+                          ],
+                          "minimum": "0",
+                          "maximum": "4"
+                        },
+                        {
+                          "formats": [
+                            {
+                              "guid": "1d6dc249-b131-5492-bab2-60d98fa73e02",
+                              "name": "fmt/199",
+                              "namespace": "http://www.nationalarchives.gov.uk"
+                            }
+                          ],
+                          "minimum": "0",
+                          "maximum": "1"
+                        }
+                      ]
+                    }
+                  }]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /representation-formats
+      summary: Create Representation Format
+      description: Creates a new Representation Format and returns the Representation
+        Format as updated.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/RepresentationFormat'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/RepresentationFormat'
+              example: ""
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /representation-formats/{guid}:
+    get:
+      tags:
+      - /representation-formats
+      summary: Get a Representation Format
+      description: Returns the Representation Format specified by the GUID of the
+        PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/RepresentationFormat'
+              example: |-
+                {
+                  "id": {
+                    "guid": "c9828123-71cc-57d0-97e2-489c71d457e0",
+                    "name": "repfmt/1",
+                    "namespace": "http://par.preservica.com"
+                  },
+                  "name": "Email",
+                  "description": "An Email is described by a primary internet message/email file. The email file may reference any number of additional files of any format that form the attachments to the email.",
+                  "representationFormatSignature": {
+                    "primaryFileCriteria": [
+                      {
+                        "formatFamilies": [
+                          {
+                            "guid": "a7069b2d-2fca-50fe-8028-ecb1a245ba5e",
+                            "name": "email",
+                            "namespace": "http://par.preservica.com"
+                          }
+                        ]
+                      }
+                    ],
+                    "fileCriteria": [
+                      {
+                        "minimum": "0",
+                        "maximum": "unbounded"
+                      }
+                    ]
+                  }
+                }
+        404:
+          description: If the specified guid does not reference a Representation Format
+            known to this registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /representation-formats
+      summary: Update Representation Format
+      description: Updates the Representation Format specified by the GUID of the
+        PAR Identifier and returns the Representation Format as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/RepresentationFormat'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/RepresentationFormat'
+              example: ""
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /representation-formats
+      summary: Delete Representation Format
+      description: Deletes the Representation Format specified by the GUID of the
+        PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Representation Format successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+  /tools:
+    get:
+      tags:
+      - /tools
+      summary: Get Tools
+      description: |-
+        Returns an array of Tools that match all of the filter conditions supplied. Any number of filters can be used together.
+        The date filters should be supplied as ISO-8601 date times or dates, i.e. yyyy-MM-ddThh:mm:ss.SZ or yyyy-MM-dd.
+        If no time information is supplied, then 00:00:00 in UTC will be assumed. This means that if you supply modified-after and modified-before dates of 2019-01-01 and 2019-12-31, you will not match any Tools modified during the day of 31st December.
+      parameters:
+      - name: guid
+        in: header
+        description: A comma separated list of GUIDs of Tools. This filter matches
+          only those Tools that are identified by one of the listed GUIDs.
+        schema:
+          type: string
+      - name: name
+        in: header
+        description: A comma separated list of names of Tools. This filter matches
+          only those Tools that are identified by one of the listed names.
+        schema:
+          type: string
+      - name: modified-after
+        in: query
+        description: This filter matches only those Tools whose local last modified
+          date is after the specified date.
+        schema:
+          type: string
+      - name: modified-before
+        in: query
+        description: This filter matches only those Tools whose local last modified
+          date is before the specified date.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: Used for requesting paged responses, this defines the offset
+          of the first Tool to return from the start of the list of all matching Tools.
+        schema:
+          type: integer
+          default: 0
+      - name: limit
+        in: query
+        description: Used for requesting paged responses, this defines the maximum
+          number of Tools to return.
+        schema:
+          type: integer
+          default: 0
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Tools'
+              example: |-
+                {
+                  "tools" : [ {
+                    "id" : {
+                      "guid" : "8fb7cc10-0c3f-56da-8be6-1d892f36abc3",
+                      "name" : "mediainfo-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "mediainfo",
+                    "toolName" : "MediaInfo CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "MediaArea - https://mediaarea.net",
+                    "toolVersion" : "18.12-1"
+                  }, {
+                    "id" : {
+                      "guid" : "efa0ee01-6a6c-5e97-ad47-eb7c08e94ad0",
+                      "name" : "libreoffice-cli",
+                      "namespace" : "http://par.preservica.com"
+                    },
+                    "toolLabel" : "soffice",
+                    "toolName" : "LibreOffice CLI",
+                    "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                    "toolPublisher" : "The Document Foundation - https://www.libreoffice.org/",
+                    "toolVersion" : "5.3.5.2"
+                  } ]
+                }
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      tags:
+      - /tools
+      summary: Create Tool
+      description: Creates a new Tool and returns the tool as created.
+      parameters:
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/Tool'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Tool'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                    "name" : "imagemagick-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "convert",
+                  "toolName" : "ImageMagick CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                  "toolVersion" : "6.7.8-9"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+  /tools/{guid}:
+    get:
+      tags:
+      - /tools
+      summary: Get a Tool
+      description: Returns the Tool specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Tool'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                    "name" : "imagemagick-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "convert",
+                  "toolName" : "ImageMagick CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                  "toolVersion" : "6.7.8-9"
+                }
+        404:
+          description: If the specified guid does not reference a Tool known to this
+            registry.
+          content: {}
+        501:
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+      - /tools
+      summary: Update Tool
+      description: Updates the Tool specified by the GUID of the PAR Identifier and
+        returns the tool as updated.
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Serialised entity in request body
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/Tool'
+        required: false
+      responses:
+        201:
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Tool'
+              example: |-
+                {
+                  "id" : {
+                    "guid" : "835e539a-abe2-55c1-b58b-8e68da664d8f",
+                    "name" : "imagemagick-cli",
+                    "namespace" : "http://par.preservica.com"
+                  },
+                  "toolLabel" : "convert",
+                  "toolName" : "ImageMagick CLI",
+                  "toolOperatingEnvironments" : [ "windows command line", "linux command line" ],
+                  "toolPublisher" : "ImageMagick Studio LLC - http://www.imagemagick.org/",
+                  "toolVersion" : "6.7.8-9"
+                }
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - /tools
+      summary: Delete Tool
+      description: Deletes the Tool specified by the GUID of the PAR Identifier
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: HTTP Basic Auth header
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Tool successfully deleted.
+          content: {}
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        501:
+          $ref: '#/components/responses/NotImplemented'
+components:
+  responses:
+    NotImplemented:
+      description: The method called is currently not implemented by this server.
+      content: {}
+    Unauthorized:
+      description: If no Authorization header has been supplied
+      content: {}
+    Forbidden:
+      description: If the supplied Authorization header does not reference a user
+        with write access to this registry.
+      content: {}
+  schemas:
+    Action:
+      type: object
+      properties:
+        optionalInputFiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputFile'
+        optionalInputProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputProperty'
+        outputFilesRetrieved:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputFile'
+        outputPropertiesRetrieved:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputProperty'
+        preservationAction:
+          $ref: '#/components/schemas/ParIdentifier'
+        priority:
+          type: integer
+          format: int32
+        rawOutputsRetrieved:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputRaw'
+    AuthorInformation:
+      type: object
+      properties:
+        authorCompoundName:
+          type: string
+        authorId:
+          type: string
+        authorIdNamespace:
+          type: string
+        authorName:
+          type: string
+        organisationName:
+          type: string
+    BusinessRule:
+      type: object
+      properties:
+        description:
+          type: string
+        formatFamilies:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        formats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        localLastModifiedDate:
+          type: string
+        notes:
+          type: string
+        preservationActionTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreservationActionType'
+        preservationActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Action'
+    BusinessRules:
+      type: object
+      properties:
+        businessRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/BusinessRule'
+    ByteSequenceInformation:
+      type: object
+      properties:
+        byteSequenceId:
+          type: string
+        byteSequenceIdNamespace:
+          type: string
+        byteSequenceValue:
+          type: string
+        encoding:
+          type: string
+          enum: ["PRONOM", "ASCII", "HEX", "REGEX_PERL"]
+          default: "PRONOM"
+        endianness:
+          type: string
+        indirectOffsetLength:
+          type: string
+        indirectOffsetLocation:
+          type: string
+        maxOffset:
+          type: string
+        offset:
+          type: string
+        positionType:
+          type: string
+    DeveloperInformation:
+      type: object
+      properties:
+        developerCompoundName:
+          type: string
+        developerId:
+          type: string
+        developerIdNamespace:
+          type: string
+        developerName:
+          type: string
+        organisationName:
+          type: string
+    DocumentInformation:
+      type: object
+      properties:
+        author:
+          $ref: '#/components/schemas/AuthorInformation'
+        availabilityDescription:
+          type: string
+        availabilityNote:
+          type: string
+        displayText:
+          type: string
+        documentIPR:
+          type: string
+        documentId:
+          type: string
+        documentIdNamespace:
+          type: string
+        documentNote:
+          type: string
+        documentType:
+          type: string
+        publicationDate:
+          type: string
+        publisher:
+          $ref: '#/components/schemas/PublisherInformation'
+        titleText:
+          type: string
+    ExternalSignatureInformation:
+      type: object
+      properties:
+        externalSignatureId:
+          type: string
+        externalSignatureIdNamespace:
+          type: string
+        signature:
+          type: string
+        signatureType:
+          type: string
+    FileCriterion:
+      type: object
+      properties:
+        formats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        formatFamilies:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        minimum:
+          type: string
+          description: (representing a number)
+        maximum:
+          type: string
+          description: (representing a number or "unbounded")
+    FileFormat:
+      type: object
+      properties:
+        aliases:
+          type: array
+          items:
+            type: string
+        binaryFileFormat:
+          type: string
+        byteOrders:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        developers:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeveloperInformation'
+        disclosure:
+          type: string
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentInformation'
+        externalSignatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExternalSignatureInformation'
+        families:
+          type: array
+          items:
+            type: string
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        identifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentifierInformation'
+        internalSignatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/InternalSignatureInformation'
+        lastUpdatedDate:
+          type: string
+        localLastModifiedDate:
+          type: string
+        name:
+          type: string
+        note:
+          type: string
+        provenance:
+          $ref: '#/components/schemas/ProvenanceInformation'
+        registryVersions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryVersionInformation'
+        relatedFormats:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelatedFormatInformation'
+        releaseDate:
+          type: string
+        risk:
+          type: string
+        technicalEnvironment:
+          type: string
+        types:
+          type: array
+          items:
+            type: string
+        version:
+          type: string
+        withdrawnDate:
+          type: string
+    FileFormats:
+      type: object
+      properties:
+        fileFormats:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileFormat'
+    FormatFamilies:
+      type: object
+      properties:
+        formatFamilies:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormatFamily'
+    FormatFamily:
+      type: object
+      properties:
+        familyType:
+          type: string
+        fileFormats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        formatFamilies:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+    IdentifierInformation:
+      type: object
+      properties:
+        identifier:
+          type: string
+        identifierType:
+          type: string
+    InputFile:
+      type: object
+      properties:
+        description:
+          type: string
+        file:
+          $ref: '#/components/schemas/ParFile'
+        name:
+          type: string
+    InputProperty:
+      type: object
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        parProperty:
+          $ref: '#/components/schemas/ParProperty'
+    InputToolArgument:
+      type: object
+      properties:
+        description:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+    InternalSignatureInformation:
+      type: object
+      properties:
+        byteSequences:
+          type: array
+          items:
+            $ref: '#/components/schemas/ByteSequenceInformation'
+        signatureId:
+          type: string
+        signatureIdNamespace:
+          type: string
+        signatureName:
+          type: string
+        signatureNote:
+          type: string
+    OutputFile:
+      type: object
+      properties:
+        description:
+          type: string
+        file:
+          $ref: '#/components/schemas/ParFile'
+        name:
+          type: string
+    OutputProperty:
+      type: object
+      properties:
+        description:
+          type: string
+        groupIdBinding:
+          type: string
+        groupLabel:
+          type: string
+        name:
+          type: string
+        parProperty:
+          $ref: '#/components/schemas/ParProperty'
+        toolBinding:
+          type: string
+    OutputRaw:
+      type: object
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+    ParFile:
+      type: object
+      properties:
+        filepath:
+          type: string
+    ParIdentifier:
+      type: object
+      properties:
+        guid:
+          type: string
+        name:
+          type: string
+        namespace:
+          type: string
+    ParProperties:
+      type: object
+      properties:
+        parProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParProperty'
+    ParProperty:
+      type: object
+      properties:
+        class:
+          type: string
+        description:
+          type: string
+        equivalentTo:
+          type: array
+          items:
+            type: string
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        localLastModifiedDate:
+          type: string
+        type:
+          type: string
+        units:
+          type: string
+        value:
+          type: string
+    PreservationAction:
+      type: object
+      properties:
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreservationActionConstraints'
+        description:
+          type: string
+        example:
+          type: string
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        inputFiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputFile'
+        inputProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputProperty'
+        inputToolArguments:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputToolArgument'
+        localLastModifiedDate:
+          type: string
+        outputFiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputFile'
+        outputProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputProperty'
+        rawOutputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputRaw'
+        tool:
+          $ref: '#/components/schemas/Tool'
+        type:
+          $ref: '#/components/schemas/PreservationActionType'
+    PreservationActionConstraints:
+      type: object
+      properties:
+        allowedFormats:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileFormat'
+        allowedPropertiesAllOf:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParProperty'
+        allowedPropertiesAnyOf:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParProperty'
+        inputItemName:
+          type: string
+    PreservationActionType:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        label:
+          type: string
+        localLastModifiedDate:
+          type: string
+    PreservationActionTypes:
+      type: object
+      properties:
+        preservationActionTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreservationActionType'
+    PreservationActions:
+      type: object
+      properties:
+        preservationActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreservationAction'
+    ProvenanceInformation:
+      type: object
+      properties:
+        provenanceDescription:
+          type: string
+        provenanceName:
+          type: string
+        provenanceSourceDate:
+          type: string
+        provenanceSourceId:
+          type: string
+        provenanceSourceNamespace:
+          type: string
+    PublisherInformation:
+      type: object
+      properties:
+        organisationName:
+          type: string
+        publisherCompoundName:
+          type: string
+        publisherId:
+          type: string
+        publisherIdNamespace:
+          type: string
+        publisherName:
+          type: string
+    RegistryVersionInformation:
+      type: object
+      properties:
+        name:
+          type: string
+        registryNamespace:
+          type: string
+        version:
+          type: string
+    RelatedFormatInformation:
+      type: object
+      properties:
+        relatedFormatId:
+          type: string
+        relatedFormatIdNamespace:
+          type: string
+        relatedFormatName:
+          type: string
+        relatedFormatVersion:
+          type: string
+        relationshipType:
+          type: string
+    RepresentationFormat:
+      type: object
+      properties:
+        description:
+          type: string
+        hasPriorityOver:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParIdentifier'
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        localLastModifiedDate:
+          type: string
+        name:
+          type: string
+        representationFormatSignature:
+          $ref: '#/components/schemas/RepresentationFormatSignature'
+    RepresentationFormats:
+      type: object
+      properties:
+        representationFormats:
+          type: array
+          items:
+            $ref: '#/components/schemas/RepresentationFormat'
+    RepresentationFormatSignature:
+      type: object
+      properties:
+        fileCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileCriterion'
+        primaryFileCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileCriterion'
+    Tool:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ParIdentifier'
+        localLastModifiedDate:
+          type: string
+        toolAcceptedParameters:
+          type: array
+          items:
+            type: string
+        toolLabel:
+          type: string
+        toolName:
+          type: string
+        toolOperatingEnvironments:
+          type: array
+          items:
+            type: string
+        toolPublisher:
+          type: string
+        toolVersion:
+          type: string
+    Tools:
+      type: object
+      properties:
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tool'

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,4 @@
+---
+layout: forward
+target: ./1.2
+---


### PR DESCRIPTION
- added API documentation publication to the `docs` folder;
  - added `docs/api`;
  - added version subfolders for 1.2, 1.1 and 1.0;
  - swagger display and versioned API YAML files added to each version folder;
  - added version submenus in `docs/_data/navbar.yml` file;
  - added submenu generation to `docs/_includes/navbar.html` file;
  - added `docs/_layouts/forward.html` layout for forward pages;
  - `/api` path is now redirected to `/api/1.2`;
- fixed erronesous source declaration in `docs/_config.yml` file;
- removed defunct `_config.yml` file in root.

Closes #9 