### PR TITLE
Allow api responses to be ordered

### DIFF
--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -133,6 +133,18 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Business Rules returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success
@@ -1065,6 +1077,18 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of FileFormats returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success
@@ -1694,6 +1718,18 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Format Families returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success
@@ -2096,6 +2132,18 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Preservation Action Types returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success
@@ -2390,6 +2438,20 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Preservation Actions returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - preservation-action-type
+            - d-name
+            - d-last-modified-date
+            - d-preservation-action-type
       responses:
         200:
           description: Success
@@ -4119,6 +4181,18 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Properties returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success
@@ -4372,14 +4446,14 @@ paths:
       - name: file-format-name
         in: header
         description: A comma separated list of names of file formats. This filter
-          matches  only those Business Rules that have been defined to apply to one
-          of  the listed formats. This includes formats where the rule is  applicable
+          matches only those Business Rules that have been defined to apply to one
+          of the listed formats. This includes formats where the rule is  applicable
           indirectly through the format family.
         schema:
           type: string
       - name: format-family-guid
         in: header
-        description: 'A comma separated list of names of formats families. This filter  matches
+        description: 'A comma separated list of GUIDs of formats families. This filter  matches
           only those Business Rules that have been defined to apply to  one of the
           listed format families. '
         schema:
@@ -4432,6 +4506,20 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of RepresentationFormats returned. 
+          Add 'd-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - id-name
+            - name
+            - last-modified-date
+            - d-id-name
+            - d-name
+            - d-last-modified-date
       responses:
         200:
           description: Success

--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -4767,13 +4767,17 @@ paths:
       - name: ordering
         in: query
         description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Tools returned.
+          to user for ordering the list of Tools returned. Add 'd-' prefix for 
+          descending order.
         schema:
           type: string
           enum:
             - toolLabel
             - toolName
             - toolVersion
+            - d-toolLabel
+            - d-toolName
+            - d-toolVersion
       responses:
         200:
           description: Success

--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -143,8 +143,8 @@ paths:
           enum:
             - name
             - last-modified-date
-            - d-name
-            - d-last-modified-date
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -1087,8 +1087,8 @@ paths:
           enum:
             - name
             - last-modified-date
-            - d-name
-            - d-last-modified-date
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -1728,8 +1728,8 @@ paths:
           enum:
             - name
             - last-modified-date
-            - d-name
-            - d-last-modified-date
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -2142,8 +2142,8 @@ paths:
           enum:
             - name
             - last-modified-date
-            - d-name
-            - d-last-modified-date
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -2449,9 +2449,9 @@ paths:
             - name
             - last-modified-date
             - preservation-action-type
-            - d-name
-            - d-last-modified-date
-            - d-preservation-action-type
+            - -name
+            - -last-modified-date
+            - -preservation-action-type
       responses:
         200:
           description: Success
@@ -4191,8 +4191,8 @@ paths:
           enum:
             - name
             - last-modified-date
-            - d-name
-            - d-last-modified-date
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -4517,9 +4517,9 @@ paths:
             - id-name
             - name
             - last-modified-date
-            - d-id-name
-            - d-name
-            - d-last-modified-date
+            - -id-name
+            - -name
+            - -last-modified-date
       responses:
         200:
           description: Success
@@ -4863,9 +4863,9 @@ paths:
             - toolLabel
             - toolName
             - toolVersion
-            - d-toolLabel
-            - d-toolName
-            - d-toolVersion
+            - -toolLabel
+            - -toolName
+            - -toolVersion
       responses:
         200:
           description: Success

--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -137,7 +137,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of Business Rules returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -1081,7 +1081,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of FileFormats returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -1722,7 +1722,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of Format Families returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -2136,7 +2136,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of Preservation Action Types returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -2442,7 +2442,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of Preservation Actions returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -4185,7 +4185,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of Properties returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -4510,7 +4510,7 @@ paths:
         in: query
         description: Used for requested ordered responses, this defines the properties
           to user for ordering the list of RepresentationFormats returned. 
-          Add 'd-' prefix for descending order.
+          Add '-' prefix for descending order.
         schema:
           type: string
           enum:
@@ -4855,7 +4855,7 @@ paths:
       - name: ordering
         in: query
         description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Tools returned. Add 'd-' prefix for 
+          to user for ordering the list of Tools returned. Add '-' prefix for 
           descending order.
         schema:
           type: string

--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -135,18 +135,7 @@ paths:
         schema:
           type: integer
           default: 0
-      - name: ordering
-        in: query
-        description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Business Rules returned. 
-          Add '-' prefix for descending order.
-        schema:
-          type: string
-          enum:
-            - name
-            - last-modified-date
-            - -name
-            - -last-modified-date
+      - $ref: '#/components/parameters/orderNameLastModDateParam'
       responses:
         200:
           description: Success
@@ -1096,18 +1085,7 @@ paths:
         schema:
           type: integer
           default: 0
-      - name: ordering
-        in: query
-        description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of FileFormats returned. 
-          Add '-' prefix for descending order.
-        schema:
-          type: string
-          enum:
-            - name
-            - last-modified-date
-            - -name
-            - -last-modified-date
+      - $ref: '#/components/parameters/orderNameLastModDateParam'
       responses:
         200:
           description: Success
@@ -1750,18 +1728,7 @@ paths:
         schema:
           type: integer
           default: 0
-      - name: ordering
-        in: query
-        description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Format Families returned. 
-          Add '-' prefix for descending order.
-        schema:
-          type: string
-          enum:
-            - name
-            - last-modified-date
-            - -name
-            - -last-modified-date
+      - $ref: '#/components/parameters/orderNameLastModDateParam'
       responses:
         200:
           description: Success
@@ -2181,18 +2148,7 @@ paths:
         schema:
           type: integer
           default: 0
-      - name: ordering
-        in: query
-        description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Preservation Action Types returned. 
-          Add '-' prefix for descending order.
-        schema:
-          type: string
-          enum:
-            - name
-            - last-modified-date
-            - -name
-            - -last-modified-date
+      - $ref: '#/components/parameters/orderNameLastModDateParam'
       responses:
         200:
           description: Success
@@ -4260,18 +4216,7 @@ paths:
         schema:
           type: integer
           default: 0
-      - name: ordering
-        in: query
-        description: Used for requested ordered responses, this defines the properties
-          to user for ordering the list of Properties returned. 
-          Add '-' prefix for descending order.
-        schema:
-          type: string
-          enum:
-            - name
-            - last-modified-date
-            - -name
-            - -last-modified-date
+      - $ref: '#/components/parameters/orderNameLastModDateParam'
       responses:
         200:
           description: Success
@@ -5882,3 +5827,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tool'
+  parameters:
+    orderNameLastModDateParam:
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the returned list. 
+          Add '-' prefix for descending order.
+        schema:
+          type: string
+          enum:
+            - name
+            - last-modified-date
+            - -name
+            - -last-modified-date

--- a/api/par-api.yaml
+++ b/api/par-api.yaml
@@ -4764,6 +4764,16 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: ordering
+        in: query
+        description: Used for requested ordered responses, this defines the properties
+          to user for ordering the list of Tools returned.
+        schema:
+          type: string
+          enum:
+            - toolLabel
+            - toolName
+            - toolVersion
       responses:
         200:
           description: Success


### PR DESCRIPTION
addresses the first half of #36 
Adds a new query parameter to each api endpoint called 'ordering'.
Also fixes some typos in the descriptions of other query parameters.