### PR TITLE
MAINT: Remove Python 3,7

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         node-version: [19.8]
 
     steps:


### PR DESCRIPTION
This is now a defunct option for GH Actions builds on the latest Ubuntu.